### PR TITLE
Fixed bug where PayPal button wouldnt update when radio text is clicked

### DIFF
--- a/js/pmpro-pay-by-check.js
+++ b/js/pmpro-pay-by-check.js
@@ -144,5 +144,6 @@ jQuery(document).ready(function () {
 	//select the radio button if the label is clicked on
 	jQuery('a.pmpro_radio').click(function () {
 		jQuery(this).prev().click();
+    pmpropbc_toggleCheckoutFields();
 	});	
 });


### PR DESCRIPTION
I'm not sure exactly when this bug occurs, but there are instances where clicking the text for the "check" radio button causes the PayPal checkout button to appear instead of the generic checkout button. Calling pmpropbc_toggleCheckoutFields() again causes the correct checkout button to appear. 