### PR TITLE
Fix PHP 8 fatal errors in `pmpropbc_reminder_emails`.

### DIFF
--- a/pmpro-pay-by-check.php
+++ b/pmpro-pay-by-check.php
@@ -700,7 +700,7 @@ function pmpropbc_recurring_orders()
 			{
 				$order = new MemberOrder($order_id);
 				$user = get_userdata($order->user_id);
-				if ($user !== false) {
+				if ( $user ) {
 					$user->membership_level = pmpro_getMembershipLevelForUser($order->user_id);
 				}
 
@@ -816,7 +816,7 @@ function pmpropbc_reminder_emails()
 				//get some data
 				$order = new MemberOrder($order_id);
 				$user = get_userdata($order->user_id);
-				if ($user !== false) {
+				if ( $user ) {
 					$user->membership_level = pmpro_getMembershipLevelForUser($order->user_id);
 				}
 
@@ -956,7 +956,7 @@ function pmpropbc_cancel_overdue_orders()
 				//get the order and user data
 				$order = new MemberOrder($order_id);
 				$user = get_userdata($order->user_id);
-				if ($user !== false) {
+				if ( $user ) {
 					$user->membership_level = pmpro_getMembershipLevelForUser($order->user_id);
 				}
 

--- a/pmpro-pay-by-check.php
+++ b/pmpro-pay-by-check.php
@@ -700,7 +700,9 @@ function pmpropbc_recurring_orders()
 			{
 				$order = new MemberOrder($order_id);
 				$user = get_userdata($order->user_id);
-				$user->membership_level = pmpro_getMembershipLevelForUser($order->user_id);
+				if ($user !== false) {
+					$user->membership_level = pmpro_getMembershipLevelForUser($order->user_id);
+				}
 
 				//check that user still has same level?
 				if(empty($user->membership_level) || $order->membership_id != $user->membership_level->id)
@@ -814,7 +816,9 @@ function pmpropbc_reminder_emails()
 				//get some data
 				$order = new MemberOrder($order_id);
 				$user = get_userdata($order->user_id);
-				$user->membership_level = pmpro_getMembershipLevelForUser($order->user_id);
+				if ($user !== false) {
+					$user->membership_level = pmpro_getMembershipLevelForUser($order->user_id);
+				}
 
 				//if they are no longer a member, let's not send them an email
 				if(empty($user->membership_level) || empty($user->membership_level->ID) || $user->membership_level->id != $order->membership_id)
@@ -952,7 +956,9 @@ function pmpropbc_cancel_overdue_orders()
 				//get the order and user data
 				$order = new MemberOrder($order_id);
 				$user = get_userdata($order->user_id);
-				$user->membership_level = pmpro_getMembershipLevelForUser($order->user_id);
+				if ($user !== false) {
+					$user->membership_level = pmpro_getMembershipLevelForUser($order->user_id);
+				}
 
 				//if they are no longer a member, let's not send them an email
 				if(empty($user->membership_level) || empty($user->membership_level->ID) || $user->membership_level->id != $order->membership_id)


### PR DESCRIPTION
This PR fixes a PHP 8 fatal error thrown in the `pmpropbc_reminder_emails` function when a WP user referenced in an order no longer exists.

From the [PHP 8 migration guide](https://www.php.net/manual/en/migration80.incompatible.php):

>A number of warnings have been converted into [Error](https://www.php.net/manual/en/class.error.php) exceptions:
> - Attempting to write to a property of a non-object. Previously this implicitly created an stdClass object for null, false and empty strings.

The fixed error:

```
PHP Fatal error:  Uncaught Error: Attempt to assign property "membership_level" on bool in /home/MY_SITE/public_html/wp-content/plugins/pmpro-pay-by-check/pmpro-pay-by-check.php:817
Stack trace:
#0 /home/MY_SITE/public_html/wp-includes/class-wp-hook.php(307): pmpropbc_reminder_emails()
#1 /home/MY_SITE/public_html/wp-includes/class-wp-hook.php(331): WP_Hook->apply_filters('', Array)
#2 /home/MY_SITE/public_html/wp-includes/plugin.php(522): WP_Hook->do_action(Array)
#3 /home/MY_SITE/public_html/wp-cron.php(138): do_action_ref_array('pmpropbc_remind...', Array)
#4 {main}
  thrown in /home/MY_SITE/public_html/wp-content/plugins/pmpro-pay-by-check/pmpro-pay-by-check.php on line 817
```

**UPDATE 2022-05-01:** found a few more spots where the same error was occurring, so I fixed those as well.