### PR TITLE
Set level access check for logged in users only

### DIFF
--- a/pmpro-pay-by-check.php
+++ b/pmpro-pay-by-check.php
@@ -533,8 +533,10 @@ function pmpropbc_pmpro_member_shortcode_access( $hasaccess, $content, $levels, 
 		return $hasaccess;
 	}
 
-	// Let's check access for logged in users.
-	if ( is_user_logged_in() ) {
+	// Let's check access for logged in users with active membership(s).
+	$levels = pmpro_getMembershipLevelsForUser( $current_user->ID );
+
+	if ( is_user_logged_in() && ! empty( $levels ) ) {
 		$hasaccess = pmprobpc_memberHasAccessWithAnyLevel( $current_user->ID );
 	}
 

--- a/pmpro-pay-by-check.php
+++ b/pmpro-pay-by-check.php
@@ -533,10 +533,8 @@ function pmpropbc_pmpro_member_shortcode_access( $hasaccess, $content, $levels, 
 		return $hasaccess;
 	}
 
-	// Let's check access for logged in users with active membership(s).
-	$levels = pmpro_getMembershipLevelsForUser( $current_user->ID );
-
-	if ( is_user_logged_in() && ! empty( $levels ) ) {
+	// We only need to run this check for logged-in user's as PMPro will handle logged-out users.
+	if ( is_user_logged_in() ) {
 		$hasaccess = pmprobpc_memberHasAccessWithAnyLevel( $current_user->ID );
 	}
 

--- a/pmpro-pay-by-check.php
+++ b/pmpro-pay-by-check.php
@@ -532,8 +532,11 @@ function pmpropbc_pmpro_member_shortcode_access( $hasaccess, $content, $levels, 
 	if ( ! $hasaccess ) {
 		return $hasaccess;
 	}
-	
-	$hasaccess = pmprobpc_memberHasAccessWithAnyLevel( $current_user->ID );
+
+	// Let's check access for logged in users.
+	if ( is_user_logged_in() ) {
+		$hasaccess = pmprobpc_memberHasAccessWithAnyLevel( $current_user->ID );
+	}
 
 	return $hasaccess;
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Only check a user's levels for content access if they are logged in.

Resolves https://github.com/strangerstudios/pmpro-pay-by-check/issues/71

### How to test the changes in this Pull Request:

1. Go to Pages > Add New and create a new page containing the shortcode `[membership level="0"]Display for non-members [/membership]` and publish the page.
2. In a new private/incognito browser navigate to this page as a non-logged-in visitor
3. Confirm that _Display for non-members_ is displayed on this page.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
