### PR TITLE
Fixes a PHP error

### DIFF
--- a/pmpro-pay-by-check.php
+++ b/pmpro-pay-by-check.php
@@ -488,9 +488,11 @@ function pmpropbc_isMemberPending($user_id, $level_id = 0)
 */
 function pmprobpc_memberHasAccessWithAnyLevel($user_id){
 	$levels = pmpro_getMembershipLevelsForUser($user_id);
-	foreach($levels as $level){
-		if(!pmpropbc_isMemberPending($user_id, $level->id)){
-			return true;
+	if( !empty( $levels ) && is_array( $levels ) ) {
+		foreach($levels as $level){
+			if(!pmpropbc_isMemberPending($user_id, $level->id)){
+				return true;
+			}
 		}
 	}
 	return false;

--- a/pmpro-pay-by-check.php
+++ b/pmpro-pay-by-check.php
@@ -488,9 +488,9 @@ function pmpropbc_isMemberPending($user_id, $level_id = 0)
 */
 function pmprobpc_memberHasAccessWithAnyLevel($user_id){
 	$levels = pmpro_getMembershipLevelsForUser($user_id);
-	if( !empty( $levels ) && is_array( $levels ) ) {
-		foreach($levels as $level){
-			if(!pmpropbc_isMemberPending($user_id, $level->id)){
+	if ( $levels && is_array( $levels ) ) {
+		foreach ( $levels as $level ) {
+			if ( ! pmpropbc_isMemberPending( $user_id, $level->id ) ) {
 				return true;
 			}
 		}


### PR DESCRIPTION
Resolves #73

Steps to reproduce the behavior:

1. Activate Pay by Check
2. Install MMPU
3. Add the following to a page:

```
[membership]
Our association is run by its members, please help to run the site by volunteering.
[/membership]

[membership level="0"]
You need to be a member to volunteer.
 [/membership]

```
See error on page:
```
( ! ) Warning: foreach() argument must be of type array|object, bool given in /Users/xxyy/Local Sites/test/app/public/wp-content/plugins/pmpro-pay-by-check/pmpro-pay-by-check.php on line 491
```

