### PR TITLE
Support Auto-Renewal Checkbox

### DIFF
--- a/pmpro-pay-by-check.php
+++ b/pmpro-pay-by-check.php
@@ -835,6 +835,11 @@ function pmpropbc_reminder_emails()
 					continue;
 				}
 
+				// If Paid Memberships Pro - Auto-Renewal Checkbox is active there may be mixed recurring and non-recurring users at ths level
+				if ( $user->membership_level->cycle_number == 0 || $user->membership_level->billing_amount == 0 ) {
+					continue;
+				}
+
 				//note when we send the reminder
 				$new_notes = $order->notes . "Reminder Sent:" . $today . "\n";
 				$wpdb->query("UPDATE $wpdb->pmpro_membership_orders SET notes = '" . esc_sql($new_notes) . "' WHERE id = '" . $order_id . "' LIMIT 1");
@@ -975,6 +980,11 @@ function pmpropbc_cancel_overdue_orders()
 					continue;
 				}
 
+				// If Paid Memberships Pro - Auto-Renewal Checkbox is active there may be mixed recurring and non-recurring users at ths level
+				if ( $user->membership_level->cycle_number == 0 || $user->membership_level->billing_amount == 0 ) {
+					continue;
+				}
+				
 				//cancel the order and subscription
 				do_action("pmpro_membership_pre_membership_expiry", $order->user_id, $order->membership_id );
 

--- a/pmpro-pay-by-check.php
+++ b/pmpro-pay-by-check.php
@@ -713,7 +713,7 @@ function pmpropbc_recurring_orders()
 				if(empty($user->membership_level) || $order->membership_id != $user->membership_level->id)
 					continue;
 
-				// If Paid Memberships Pro - Auto-Renewal Checkbox is active there may be mixed recurring and non-recurring users at ths level
+				// If Paid Memberships Pro - Auto-Renewal Checkbox is active there may be mixed recurring and non-recurring users at this level
 				if( $user->membership_level->cycle_number == 0 || $user->membership_level->billing_amount == 0)
 				  continue;
 
@@ -835,7 +835,7 @@ function pmpropbc_reminder_emails()
 					continue;
 				}
 
-				// If Paid Memberships Pro - Auto-Renewal Checkbox is active there may be mixed recurring and non-recurring users at ths level
+				// If Paid Memberships Pro - Auto-Renewal Checkbox is active there may be mixed recurring and non-recurring users at this level
 				if ( $user->membership_level->cycle_number == 0 || $user->membership_level->billing_amount == 0 ) {
 					continue;
 				}
@@ -980,11 +980,11 @@ function pmpropbc_cancel_overdue_orders()
 					continue;
 				}
 
-				// If Paid Memberships Pro - Auto-Renewal Checkbox is active there may be mixed recurring and non-recurring users at ths level
+				// If Paid Memberships Pro - Auto-Renewal Checkbox is active there may be mixed recurring and non-recurring users at this level
 				if ( $user->membership_level->cycle_number == 0 || $user->membership_level->billing_amount == 0 ) {
 					continue;
 				}
-				
+
 				//cancel the order and subscription
 				do_action("pmpro_membership_pre_membership_expiry", $order->user_id, $order->membership_id );
 


### PR DESCRIPTION
Support Auto-Renewal Checkbox for reminder emails and cancel overdue orders. This may also help with other cases of prematurely expiring.

Resolves https://github.com/strangerstudios/pmpro-pay-by-check/issues/69