### PR TITLE
Fix membership shortcode for non-member users

### DIFF
--- a/pmpro-pay-by-check.php
+++ b/pmpro-pay-by-check.php
@@ -579,7 +579,7 @@ function pmpropbc_pmpro_member_shortcode_access( $hasaccess, $content, $levels, 
 
 	// If we are checking if the user is not a member, we don't want to hide this content if they are pending.
 	foreach ( $levels as $level ) {
-		if ( $level <= 0 ) {
+		if ( intval( $level ) <= 0 ) {
 			return $hasaccess;
 		}
 	}

--- a/pmpro-pay-by-check.php
+++ b/pmpro-pay-by-check.php
@@ -577,6 +577,13 @@ function pmpropbc_pmpro_member_shortcode_access( $hasaccess, $content, $levels, 
 		return $hasaccess;
 	}
 
+	// If we are checking if the user is not a member, we don't want to hide this content if they are pending.
+	foreach ( $levels as $level ) {
+		if ( $level <= 0 ) {
+			return $hasaccess;
+		}
+	}
+
 	// We only need to run this check for logged-in user's as PMPro will handle logged-out users.
 	if ( is_user_logged_in() ) {
 		$hasaccess = pmprobpc_memberHasAccessWithAnyLevel( $current_user->ID );


### PR DESCRIPTION
Issue:
1. Using shortcode `[membership level="0"]`
2. Logged in user without a membership level tries to view the content and should be able to
3. `is_user_logged_in()` will be `true`
4. `pmprobpc_memberHasAccessWithAnyLevel( $current_user->ID )` will set `$hasaccess` to false since the user does not have a membership level

This behavior is incorrect. If we are trying to show content to non-members, then we absolutely don't want to hide the content because this logged-in non-member don't have a level.