### PR TITLE
Fixes an error on the confirmation page

### DIFF
--- a/pmpro-pay-by-check.php
+++ b/pmpro-pay-by-check.php
@@ -660,7 +660,7 @@ function pmpropbc_confirmation_message( $confirmation_message, $invoice ) {
 
 	$user = get_user_by( 'ID', $invoice->user_id );
 	
-	$confirmation_message = '<p>' . sprintf( __( 'Thank you for your membership to %1$s. Your %2$s membership status is: <b>%3$s</b>.', 'pmpro-pay-by-check' ), get_bloginfo( 'name' ), $user->membership_level->name, $invoice->status ) . ' ' . __( 'Once payment is received and processed you will gain access to your membership content.', 'pmpro-pay-by-check' ) . '</p>';
+	$confirmation_message = '<p>' . sprintf( __( 'Thank you for your membership to %1$s. Your %2$s membership status is: <b>%3$s</b>.', 'pmpro-pay-by-check' ), get_bloginfo( 'name' ), $invoice->membership_level->name, $invoice->status ) . ' ' . __( 'Once payment is received and processed you will gain access to your membership content.', 'pmpro-pay-by-check' ) . '</p>';
 
 	// Put the level confirmation from level settings into the message.
 	if ( ! empty( $user->membership_level->confirmation ) ) {


### PR DESCRIPTION
Once you've reached the confrmation page an error is thrown:

Warning: Attempt to read property "name" on string in C:\Users\info\Local Sites\paid-memberships-pro\app\public\wp-content\plugins\pmpro-pay-by-check\pmpro-pay-by-check.php on line 663

This references the membership level name. 

We currently reference the user -> membership level but this hasn't been assigned yet because the order is still pending.

Instead, we've opted to reference the invoice -> membership level. 