### PR TITLE
Removes the PPExp Toggle Section for a Check Only level

### DIFF
--- a/pmpro-pay-by-check.php
+++ b/pmpro-pay-by-check.php
@@ -320,6 +320,9 @@ function pmpropbc_init_include_billing_address_fields()
 			//hide billing address and payment info fields
 			add_filter('pmpro_include_billing_address_fields', '__return_false', 20);
 			add_filter('pmpro_include_payment_information_fields', '__return_false', 20);
+
+			//Hide the toggle section if the PayPal Express Add On is active
+			remove_action( "pmpro_checkout_boxes", "pmproappe_pmpro_checkout_boxes", 20 );
 		} else {
 			//keep paypal buttons, billing address fields/etc at checkout
 			$default_gateway = pmpro_getOption('gateway');


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The PayPal Express Add On adds a toggle section which doesn't get removed for levels that only allow a Check payment. 

This removes that section where necessary.

### How to test the changes in this Pull Request:

1. Activate PMPro, PayPal Express Add On and Pay By Check Add On
2. Set a level to only allow payment by Check
3. The toggle/radio buttons should no longer show on checkout

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Check only levels no longer show multiple gateway options