### PR TITLE
No longer pulling level from $_REQUEST

### DIFF
--- a/pmpro-pay-by-check.php
+++ b/pmpro-pay-by-check.php
@@ -279,16 +279,11 @@ add_filter("pmpro_valid_gateways", "pmpropbc_pmpro_valid_gateways");
 */
 function pmpropbc_pmpro_get_gateway($gateway)
 {
-	global $pmpro_level;
+	$level = pmpro_getLevelAtCheckout();
 
-	if(!empty($pmpro_level) || !empty($_REQUEST['level']))
+	if ( ! empty( $level->id ) )
 	{
-		if(!empty($pmpro_level))
-			$level_id = $pmpro_level->id;
-		else
-			$level_id = intval($_REQUEST['level']);
-
-		$options = pmpropbc_getOptions($level_id);
+		$options = pmpropbc_getOptions( $level->id );
 
     	if($options['setting'] == 2)
     		$gateway = "check";
@@ -310,10 +305,10 @@ function pmpropbc_init_include_billing_address_fields()
 		return;
 
 	//billing address and payment info fields
-	if(!empty($_REQUEST['level']))
+	$level = pmpro_getLevelAtCheckout();
+	if ( ! empty( $level->id ) )
 	{
-		$level_id = intval($_REQUEST['level']);
-		$options = pmpropbc_getOptions($level_id);
+		$options = pmpropbc_getOptions( $level->id );
     			
 		if($options['setting'] == 2)
 		{


### PR DESCRIPTION
Should only be merged once this PR is confirmed to be merged into the PMPro v3.0 branch: https://github.com/strangerstudios/paid-memberships-pro/pull/2506

This PR specifically stops pulling the checkout level from the `$_REQUEST` variable (since we are prefixing the `level` parameter in 3.0) and instead uses the `pmpro_getLevelAtCheckout()` function.