### PR TITLE
Setting order status to error on failed payment

### DIFF
--- a/pmpro-pay-by-check.php
+++ b/pmpro-pay-by-check.php
@@ -1181,6 +1181,12 @@ function pmpropbc_cancel_overdue_orders()
 
 				//remove their membership
 				pmpro_changeMembershipLevel(false, $order->user_id, 'expired');
+
+				// Update the order.
+				$order->status = 'error';
+				$order->notes .= "Cancelled:" . $today . "\n";
+				$order->saveOrder();
+
 				do_action("pmpro_membership_post_membership_expiry", $order->user_id, $order->membership_id );
 				$send_email = apply_filters("pmpro_send_expiration_email", true, $order->user_id);
 				if($send_email)


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-pay-by-check/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-pay-by-check/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Noting the date that an order is cancelled (as the query above expects that data to be there) and now setting the order status to "Error" to discourage admins from later trying to switch it to success, even though the user has already lost their membership.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
