### PR TITLE
Adds support when using PBC with Address for Free Levels

### DIFF
--- a/pmpro-pay-by-check.php
+++ b/pmpro-pay-by-check.php
@@ -316,6 +316,9 @@ function pmpropbc_init_include_billing_address_fields()
 			add_filter('pmpro_include_billing_address_fields', '__return_false', 20);
 			add_filter('pmpro_include_payment_information_fields', '__return_false', 20);
 
+			//Make sure the billing address fields aren't still required when using the Address for Free Levels Add On
+			remove_action("pmpro_required_billing_fields", "pmproaffl_pmpro_required_billing_fields", 30);
+
 			//Hide the toggle section if the PayPal Express Add On is active
 			remove_action( "pmpro_checkout_boxes", "pmproappe_pmpro_checkout_boxes", 20 );
 		} else {

--- a/pmpro-pay-by-check.php
+++ b/pmpro-pay-by-check.php
@@ -313,7 +313,7 @@ function pmpropbc_init_include_billing_address_fields()
 		if($options['setting'] == 2)
 		{
 			//Only hide the address if we're not using the Address for Free Levels Add On
-			if( ! function_exists( 'pmproaffl_pmpro_required_billing_fields' ) ) {				
+			if ( ! function_exists( 'pmproaffl_pmpro_required_billing_fields' ) ) {				
 				//hide billing address and payment info fields
 				add_filter('pmpro_include_billing_address_fields', '__return_false', 20);
 				add_filter('pmpro_include_payment_information_fields', '__return_false', 20);

--- a/pmpro-pay-by-check.php
+++ b/pmpro-pay-by-check.php
@@ -312,12 +312,12 @@ function pmpropbc_init_include_billing_address_fields()
     			
 		if($options['setting'] == 2)
 		{
-			//hide billing address and payment info fields
-			add_filter('pmpro_include_billing_address_fields', '__return_false', 20);
-			add_filter('pmpro_include_payment_information_fields', '__return_false', 20);
-
-			//Make sure the billing address fields aren't still required when using the Address for Free Levels Add On
-			remove_action("pmpro_required_billing_fields", "pmproaffl_pmpro_required_billing_fields", 30);
+			//Only hide the address if we're not using the Address for Free Levels Add On
+			if( ! function_exists( 'pmproaffl_pmpro_required_billing_fields' ) ) {				
+				//hide billing address and payment info fields
+				add_filter('pmpro_include_billing_address_fields', '__return_false', 20);
+				add_filter('pmpro_include_payment_information_fields', '__return_false', 20);
+			}
 
 			//Hide the toggle section if the PayPal Express Add On is active
 			remove_action( "pmpro_checkout_boxes", "pmproappe_pmpro_checkout_boxes", 20 );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-pay-by-check/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-pay-by-check/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Marks the address field as not required, even though they've been hidden already

### How to test the changes in this Pull Request:

1. Set up a level with the PBC Add On and set a level to only be able to checkout with a check
2. Activate the Address for Free Levels Add On
3. Run a test checkout

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

