### PR TITLE
Improving performance by no longer filtering gateway option

### DIFF
--- a/js/pmpro-pay-by-check.js
+++ b/js/pmpro-pay-by-check.js
@@ -40,7 +40,7 @@ function pmpropbc_isLevelFree() {
 }
 
 function pmpropbc_isCheckGatewayChosen() {
-	if(jQuery('input[name=gateway]:checked').val() === 'check') {
+	if(jQuery('input[name=gateway]:checked').val() === 'check' || pmpropbc.check_only === '1') {
 		return true;
 	} else {
 		return false;

--- a/pmpro-pay-by-check.php
+++ b/pmpro-pay-by-check.php
@@ -331,6 +331,9 @@ function pmpropbc_init_include_billing_address_fields()
 			add_filter('pmpro_include_billing_address_fields', '__return_false', 20);
 			add_filter('pmpro_include_payment_information_fields', '__return_false', 20);
 
+			// Need to also specifically remove them for Stripe.
+			remove_filter( 'pmpro_include_payment_information_fields', array( 'PMProGateway_stripe', 'pmpro_include_payment_information_fields' ) );
+
 			//Hide the toggle section if the PayPal Express Add On is active
 			remove_action( "pmpro_checkout_boxes", "pmproappe_pmpro_checkout_boxes", 20 );
 		} else {

--- a/pmpro-pay-by-check.php
+++ b/pmpro-pay-by-check.php
@@ -294,6 +294,8 @@ add_filter("pmpro_valid_gateways", "pmpropbc_pmpro_valid_gateways");
  */
 function pmpropbc_pmpro_get_gateway($gateway)
 {
+	_deprecated_function( __FUNCTION__, 'TBD' );
+
 	$level = pmpro_getLevelAtCheckout();
 
 	if ( ! empty( $level->id ) )


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-pay-by-check/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-pay-by-check/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
In the last update, we began using the `pmpro_getLevelAtCheckout()` function to avoid pulling level IDs directly from the `$_REQUEST` variable. This came with some performance issues where some sites were running out of PHP memory. Looking at the backtrace for a site, the issue originated from the `pmpropbc_pmpro_get_gateway()` function.

The first thought here was to try to make that function more efficient by using caching or limiting when it runs, but taking a step back, that plugin seems unnecessary altogether. The `pmpropbc_pmpro_get_gateway()` function only actually ever has an effect if the level being purchased is a "pay by check only" level. Levels that can be purchased via check or another gateway do not use this code and work correctly. So the `pmpropbc_pmpro_get_gateway()` function does not actually seem necessary and is clearly a liability.

This PR proposes deprecating the `pmpropbc_pmpro_get_gateway()` function entirely and instead switching to using the method that is already being used by levels that can be paid for by both check or another gateway, which is also the same method that is used in the Add PayPal Express Add On.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
