### PR TITLE
Fixing order timestamp, removing dupe/wrong query

### DIFF
--- a/pmpro-pay-by-check.php
+++ b/pmpro-pay-by-check.php
@@ -906,17 +906,14 @@ function pmpropbc_recurring_orders()
 				$order_timestamp = strtotime("+" . $combo, $order->timestamp);
 
 				//let's skip if there is already an order for this user/level/timestamp
-				$sqlQuery = "SELECT id FROM $wpdb->pmpro_membership_orders WHERE user_id = '" . $order->user_id . "' AND membership_id = '" . $order->membership_id . "' AND timestamp = '" . date('d', $order_timestamp) . "' LIMIT 1";
-				$dupe = $wpdb->get_var("SELECT id FROM $wpdb->pmpro_membership_orders WHERE user_id = '" . $order->user_id . "' AND membership_id = '" . $order->membership_id . "' AND timestamp = '" . $order_timestamp . "' LIMIT 1");
+				$dupe = $wpdb->get_var("SELECT id FROM $wpdb->pmpro_membership_orders WHERE user_id = '" . $order->user_id . "' AND membership_id = '" . $order->membership_id . "' AND timestamp >= '" . date('Y-m-d H:i:s', $order_timestamp) . "' LIMIT 1");
 				if(!empty($dupe))
 					continue;
 
 				//save it
 				$morder->process();
+				$morder->timestamp = $order_timestamp;
 				$morder->saveOrder();
-
-				//update the timestamp
-				$morder->updateTimestamp(date("Y", $order_timestamp), date("m", $order_timestamp), date("d", $order_timestamp));
 
 				//send emails
 				$email = new PMProEmail();

--- a/pmpro-pay-by-check.php
+++ b/pmpro-pay-by-check.php
@@ -906,7 +906,8 @@ function pmpropbc_recurring_orders()
 				$order_timestamp = strtotime("+" . $combo, $order->timestamp);
 
 				//let's skip if there is already an order for this user/level/timestamp
-				$dupe = $wpdb->get_var("SELECT id FROM $wpdb->pmpro_membership_orders WHERE user_id = '" . $order->user_id . "' AND membership_id = '" . $order->membership_id . "' AND timestamp >= '" . date('Y-m-d H:i:s', $order_timestamp) . "' LIMIT 1");
+				// Giving 1 day of wiggle room to avoid duplicate orders being created after updating to this new logic.
+				$dupe = $wpdb->get_var("SELECT id FROM $wpdb->pmpro_membership_orders WHERE user_id = '" . $order->user_id . "' AND membership_id = '" . $order->membership_id . "' AND timestamp >= '" . date( 'Y-m-d H:i:s', $order_timestamp - 60 * 60 * 24 ) . "' LIMIT 1");
 				if(!empty($dupe))
 					continue;
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-pay-by-check/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-pay-by-check/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
- Fixing issue where new order would not carry over time from previous order
- Removing unused query
- Fixing `timestamp` variable in query to be a datetime like SQL expects

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
