### PR TITLE
Fixing $combo issues

### DIFF
--- a/pmpro-pay-by-check.php
+++ b/pmpro-pay-by-check.php
@@ -879,6 +879,11 @@ function pmpropbc_recurring_orders()
 				if( $user->membership_level->cycle_number == 0 || $user->membership_level->billing_amount == 0)
 				  continue;
 
+				// Make sure that the user's billing structure is the same as the billing structure that we are checking for ($combo).
+				if ( $user->membership_level->cycle_number . ' ' . $user->membership_level->cycle_period != $combo ) {
+					continue;
+				}
+
 				//create new pending order
 				$morder = new MemberOrder();
 				$morder->user_id = $order->user_id;
@@ -1060,6 +1065,11 @@ function pmpropbc_reminder_emails()
 					continue;
 				}
 
+				// Make sure that the user's billing structure is the same as the billing structure that we are checking for ($combo).
+				if ( $user->membership_level->cycle_number . ' ' . $user->membership_level->cycle_period != $combo ) {
+					continue;
+				}
+
 				//note when we send the reminder
 				$new_notes = $order->notes . "Reminder Sent:" . $today . "\n";
 				$wpdb->query("UPDATE $wpdb->pmpro_membership_orders SET notes = '" . esc_sql($new_notes) . "' WHERE id = '" . $order_id . "' LIMIT 1");
@@ -1202,6 +1212,11 @@ function pmpropbc_cancel_overdue_orders()
 
 				// If Paid Memberships Pro - Auto-Renewal Checkbox is active there may be mixed recurring and non-recurring users at this level
 				if ( $user->membership_level->cycle_number == 0 || $user->membership_level->billing_amount == 0 ) {
+					continue;
+				}
+
+				// Make sure that the user's billing structure is the same as the billing structure that we are checking for ($combo).
+				if ( $user->membership_level->cycle_number . ' ' . $user->membership_level->cycle_period != $combo ) {
 					continue;
 				}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-pay-by-check/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-pay-by-check/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Fixing issue where each $combo is being applied to each user's membership regardless of the actual cycle period/cycle number set for that membership, meaning that users may have orders created when they should not be.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves #60 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
