### PR TITLE
Fixes an error caused by no attr in membership shortcode

### DIFF
--- a/pmpro-pay-by-check.php
+++ b/pmpro-pay-by-check.php
@@ -630,6 +630,11 @@ function pmpropbc_pmpro_member_shortcode_access( $hasaccess, $content, $levels, 
 		return $hasaccess;
 	}
 
+	//If no levels attribute is added to the shortcode, assume access for any level
+	if( ! is_array( $levels ) ) {
+		return pmprobpc_memberHasAccessWithAnyLevel( $current_user->ID, $levels );
+	}
+
 	// If we are checking if the user is not a member, we don't want to hide this content if they are pending.
 	foreach ( $levels as $level ) {
 		if ( intval( $level ) <= 0 ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-pay-by-check/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-pay-by-check/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes a PHP error that is caused by the [membership] shortcode not having a levels attribute

### How to test the changes in this Pull Request:

1. Add the `[membership]` shortcode to a page
2. Sign up for a level with a check payment
3. Visit the page - No error should show. Previously: `Warning: foreach() argument must be of type array|object, bool given in /Users/jarrydlong/Local Sites/paid-memberships-pro/app/public/wp-content/plugins/pmpro-pay-by-check/pmpro-pay-by-check.php on line 634`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

