### PR TITLE
Adding basic compatibility with subs table

### DIFF
--- a/pmpro-pay-by-check.php
+++ b/pmpro-pay-by-check.php
@@ -771,6 +771,14 @@ function pmpropbc_send_invoice_email( $morder ) {
 		return;
 	}
 
+	// If using PMPro v3.0+, update the subscription data.
+	if ( method_exists( $morder, 'get_subscription' ) ) {
+		$subscription = $morder->get_subscription();
+		if ( ! empty( $subscription ) ) {
+			$subscription->update();
+		}
+	}
+
 	// Check order meta to see if an invoice email has already been sent for this order.
 	if ( function_exists( 'get_pmpro_membership_order_meta' ) && get_pmpro_membership_order_meta( $morder->id, 'pmpropbc_invoice_email_sent', true ) ) {
 		return;
@@ -874,6 +882,15 @@ function pmpropbc_recurring_orders()
 			foreach($orders as $order_id)
 			{
 				$order = new MemberOrder($order_id);
+
+				// If using PMPro v3.0+, only create a pending order if the subscription is still active.
+				if ( method_exists( $order, 'get_subscription' ) ) {
+					$subscription = $order->get_subscription();
+					if ( ! empty( $subscription ) && 'active' !== $subscription->get_status() ) {
+						continue;
+					}
+				}
+
 				$user = get_userdata($order->user_id);
 				if ( $user ) {
 					$user->membership_level = pmpro_getSpecificMembershipLevelForUser( $order->user_id, $level->id );
@@ -1052,6 +1069,15 @@ function pmpropbc_reminder_emails()
 			{
 				//get some data
 				$order = new MemberOrder($order_id);
+
+				// If using PMPro v3.0+, only send reminders if the subscription is still active.
+				if ( method_exists( $order, 'get_subscription' ) ) {
+					$subscription = $order->get_subscription();
+					if ( ! empty( $subscription ) && 'active' !== $subscription->get_status() ) {
+						continue;
+					}
+				}
+
 				$user = get_userdata($order->user_id);
 				if ( $user ) {
 					$user->membership_level = pmpro_getSpecificMembershipLevelForUser( $order->user_id, $level->id );
@@ -1202,6 +1228,15 @@ function pmpropbc_cancel_overdue_orders()
 			{
 				//get the order and user data
 				$order = new MemberOrder($order_id);
+
+				// If using PMPro v3.0+, only process overdue orders if the subscription is still active.
+				if ( method_exists( $order, 'get_subscription' ) ) {
+					$subscription = $order->get_subscription();
+					if ( ! empty( $subscription ) && 'active' !== $subscription->get_status() ) {
+						continue;
+					}
+				}
+
 				$user = get_userdata($order->user_id);
 				if ( $user ) {
 					$user->membership_level = pmpro_getSpecificMembershipLevelForUser( $order->user_id, $level->id );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-pay-by-check/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-pay-by-check/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Adds basic compatibility with subs table by updating subscription data when a check payment is received and not acting on a PBC subscription if the corresponding subscription in subs table has been cancelled.

This PR does not switch the Add On to fully rely on subs table, only bridges the gap for the time being. For full compatibility, see this issue:
https://github.com/strangerstudios/pmpro-pay-by-check/issues/109

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
