### PR TITLE
Now relying on subs table when using PMPro v3.0+

### DIFF
--- a/includes/deprecated.php
+++ b/includes/deprecated.php
@@ -1,0 +1,480 @@
+<?php
+
+/*
+	Create pending orders for recurring levels.
+*/
+function pmpropbc_recurring_orders_legacy() {
+	global $wpdb;
+
+	//make sure we only run once a day
+	$now = current_time('timestamp');
+	$today = date("Y-m-d", $now);
+
+	//have to run for each level, so get levels
+	$levels = pmpro_getAllLevels(true, true);
+
+	if(empty($levels))
+		return;
+
+	foreach($levels as $level)
+	{
+		//get options
+		$options = pmpropbc_getOptions($level->id);
+		if(!empty($options['renewal_days']))
+			$date = date("Y-m-d", strtotime("+ " . $options['renewal_days'] . " days", $now));
+		else
+			$date = $today;
+
+		//need to get all combos of pay cycle and period
+		$sqlQuery = "SELECT DISTINCT(CONCAT(cycle_number, ' ', cycle_period)) FROM $wpdb->pmpro_memberships_users WHERE membership_id = '" . $level->id . "' AND cycle_number > 0 AND status = 'active'";
+		$combos = $wpdb->get_col($sqlQuery);
+
+		if(empty($combos))
+			continue;
+
+		foreach($combos as $combo)
+		{
+			//check if it's been one pay period since the last payment
+			/*
+				- Check should create an invoice X days before expiration based on a setting on the levels page.
+				- Set invoice date based on cycle and the day of the month of the member start date.
+				- Send a reminder email Y days after initial invoice is created if it's still pending.
+				- Cancel membership after Z days if invoice is not paid. Send email.
+// ADDED Extra brackets round OR as sql results were missing some orders (match for same user id was not being used due to the missing brackets) 
+			*/
+			//get all check orders still pending after X days
+			$sqlQuery = "
+				SELECT o1.id FROM
+				    (SELECT mo.id, mo.user_id, mo.timestamp
+				    FROM {$wpdb->pmpro_membership_orders} AS mo
+				    WHERE mo.membership_id = $level->id
+				        AND mo.gateway = 'check'
+				        AND mo.status IN('pending', 'success')
+				    ) as o1
+
+					LEFT OUTER JOIN 
+					
+					(SELECT mo1.id, mo1.user_id, mo1.timestamp
+				    FROM {$wpdb->pmpro_membership_orders} AS mo1
+				    WHERE mo1.membership_id = $level->id
+				        AND mo1.gateway = 'check'
+				        AND mo1.status IN('pending', 'success')
+				    ) as o2
+
+					ON o1.user_id = o2.user_id
+					AND (o1.timestamp < o2.timestamp
+					OR (o1.timestamp = o2.timestamp AND o1.id < o2.id))
+				WHERE
+					o2.id IS NULL
+					AND DATE_ADD(o1.timestamp, INTERVAL $combo) <= '" . $date . "'
+			";
+
+			if(defined('PMPRO_CRON_LIMIT'))
+				$sqlQuery .= " LIMIT " . PMPRO_CRON_LIMIT;
+
+			$orders = $wpdb->get_col($sqlQuery);
+
+			if(empty($orders))
+				continue;
+
+			foreach($orders as $order_id)
+			{
+				$order = new MemberOrder($order_id);
+
+				$user = get_userdata($order->user_id);
+				if ( $user ) {
+					$user->membership_level = pmpro_getSpecificMembershipLevelForUser( $order->user_id, $level->id );
+				}
+
+				//check that user still has same level?
+				if(empty($user->membership_level) || $order->membership_id != $user->membership_level->id)
+					continue;
+
+				// If Paid Memberships Pro - Auto-Renewal Checkbox is active there may be mixed recurring and non-recurring users at this level
+				if( $user->membership_level->cycle_number == 0 || $user->membership_level->billing_amount == 0)
+				  continue;
+
+				// Make sure that the user's billing structure is the same as the billing structure that we are checking for ($combo).
+				if ( $user->membership_level->cycle_number . ' ' . $user->membership_level->cycle_period != $combo ) {
+					continue;
+				}
+
+				//create new pending order
+				$morder = new MemberOrder();
+				$morder->user_id = $order->user_id;
+				$morder->membership_id = $user->membership_level->id;
+				$morder->InitialPayment = $user->membership_level->billing_amount;
+				$morder->PaymentAmount = $user->membership_level->billing_amount;
+				$morder->BillingPeriod = $user->membership_level->cycle_period;
+				$morder->BillingFrequency = $user->membership_level->cycle_number;
+				$morder->subscription_transaction_id = $order->subscription_transaction_id;
+				$morder->gateway = "check";
+				$morder->setGateway();
+				$morder->payment_type = "Check";
+				$morder->status = "pending";
+
+				// Copy billing addres from last order
+				$morder->billing = new stdClass();
+				$morder->billing->name = $order->billing->name;
+				$morder->billing->street = $order->billing->street;
+				$morder->billing->city = $order->billing->city;
+				$morder->billing->state = $order->billing->state;
+				$morder->billing->zip = $order->billing->zip;
+				$morder->billing->country = $order->billing->country;
+
+				//get timestamp for new order
+				$order_timestamp = strtotime("+" . $combo, $order->timestamp);
+
+				//let's skip if there is already an order for this user/level/timestamp
+				// make sure there's no order for the current order_timesamp (ignore hours/seconds and focus on the day value itself).
+				$dupe = $wpdb->get_var( "SELECT id FROM $wpdb->pmpro_membership_orders WHERE user_id = '" . esc_sql( $order->user_id ) . "' AND membership_id = '" . esc_sql( $order->membership_id ) . "' AND timestamp LIKE '" . esc_sql( date( 'Y-m-d', $order_timestamp ) ) . "%' LIMIT 1" );
+
+				if(!empty($dupe))
+					continue;
+
+				//save it
+				$morder->process();
+				$morder->timestamp = $order_timestamp;
+				$morder->saveOrder();
+
+				//send emails
+				$email = new PMProEmail();
+				$email->template = "check_pending";
+				$email->email = $user->user_email;
+				$email->subject = sprintf(__("New Invoice for %s at %s", "pmpro-pay-by-check"), $user->membership_level->name, get_option("blogname"));
+
+				//get body from template
+				$email->body = file_get_contents(PMPRO_PAY_BY_CHECK_DIR . "/email/" . $email->template . ".html");
+
+				//setup more data
+				$email->data = array(
+					"name" => $user->display_name,
+					"user_login" => $user->user_login,
+					"sitename" => get_option("blogname"),
+					"siteemail" => pmpro_getOption("from_email"),
+					"membership_id" => $user->membership_level->id,
+					"membership_level_name" => $user->membership_level->name,
+					"membership_cost" => pmpro_getLevelCost($user->membership_level),
+					"login_link" => wp_login_url(pmpro_url("account")),
+					"display_name" => $user->display_name,
+					"user_email" => $user->user_email,
+				);
+
+				$email->data["instructions"] = wp_unslash(  pmpro_getOption('instructions') );
+				$email->data["invoice_id"] = $morder->code;
+				$email->data["invoice_total"] = pmpro_formatPrice($morder->total);
+				$email->data["invoice_date"] = date(get_option('date_format'), $morder->timestamp);
+				$email->data["billing_name"] = $morder->billing->name;
+				$email->data["billing_street"] = $morder->billing->street;
+				$email->data["billing_city"] = $morder->billing->city;
+				$email->data["billing_state"] = $morder->billing->state;
+				$email->data["billing_zip"] = $morder->billing->zip;
+				$email->data["billing_country"] = $morder->billing->country;
+				$email->data["billing_phone"] = $morder->billing->phone;
+				$email->data["cardtype"] = $morder->cardtype;
+				$email->data["accountnumber"] = hideCardNumber($morder->accountnumber);
+				$email->data["expirationmonth"] = $morder->expirationmonth;
+				$email->data["expirationyear"] = $morder->expirationyear;
+				$email->data["billing_address"] = pmpro_formatAddress($morder->billing->name,
+																	 $morder->billing->street,
+																	 "", //address 2
+																	 $morder->billing->city,
+																	 $morder->billing->state,
+																	 $morder->billing->zip,
+																	 $morder->billing->country,
+																	 $morder->billing->phone);
+
+				if($morder->getDiscountCode())
+					$email->data["discount_code"] = "<p>" . __("Discount Code", "pmpro") . ": " . $morder->discount_code->code . "</p>\n";
+				else
+					$email->data["discount_code"] = "";
+
+				//send the email
+				$email->sendEmail();
+			}
+		}
+	}
+}
+
+/*
+	Send reminder emails for pending invoices.
+*/
+function pmpropbc_reminder_emails_legacy()
+{
+	global $wpdb;
+
+	//make sure we only run once a day
+	$now = current_time('timestamp');
+	$today = date("Y-m-d", $now);
+
+	//have to run for each level, so get levels
+	$levels = pmpro_getAllLevels(true, true);
+
+	if(empty($levels))
+		return;
+
+	foreach($levels as $level)
+	{
+		//get options
+		$options = pmpropbc_getOptions($level->id);
+		// subtract reminder_days from current date as we are looking for invoices from or before that date
+		// this is relative to the date the reminder was sent out not when it was due I think
+		if(!empty($options['reminder_days']))
+			$date = date("Y-m-d", strtotime("- " . $options['reminder_days'] . " days", $now));
+		else
+			$date = $today;
+
+		//need to get all combos of pay cycle and period
+		$sqlQuery = "SELECT DISTINCT(CONCAT(cycle_number, ' ', cycle_period)) FROM $wpdb->pmpro_memberships_users WHERE membership_id = '" . $level->id . "' AND cycle_number > 0 AND status = 'active'";
+		$combos = $wpdb->get_col($sqlQuery);
+
+		if(empty($combos))
+			continue;
+
+		foreach($combos as $combo)
+		{
+			//get all check orders still pending after X days
+		  // don't add the INTERVAL here!
+			$sqlQuery = "
+				SELECT id 
+				FROM $wpdb->pmpro_membership_orders 
+				WHERE membership_id = $level->id 
+					AND gateway = 'check' 
+					AND status = 'pending' 
+					AND timestamp <= '" . $date . "'
+					AND notes NOT LIKE '%Reminder Sent:%' AND notes NOT LIKE '%Reminder Skipped:%'
+				ORDER BY id
+			";
+
+			if(defined('PMPRO_CRON_LIMIT'))
+				$sqlQuery .= " LIMIT " . PMPRO_CRON_LIMIT;
+
+			$orders = $wpdb->get_col($sqlQuery);
+
+			if(empty($orders))
+				continue;
+
+			foreach($orders as $order_id)
+			{
+				//get some data
+				$order = new MemberOrder($order_id);
+
+				// If using PMPro v3.0+, only send reminders if the subscription is still active.
+				if ( method_exists( $order, 'get_subscription' ) ) {
+					$subscription = $order->get_subscription();
+					if ( ! empty( $subscription ) && 'active' !== $subscription->get_status() ) {
+						continue;
+					}
+				}
+
+				$user = get_userdata($order->user_id);
+				if ( $user ) {
+					$user->membership_level = pmpro_getSpecificMembershipLevelForUser( $order->user_id, $level->id );
+				}
+
+				//if they are no longer a member, let's not send them an email
+				if(empty($user->membership_level) || empty($user->membership_level->ID) || $user->membership_level->id != $order->membership_id)
+				{
+					//note when we send the reminder
+					$new_notes = $order->notes . "Reminder Skipped:" . $today . "\n";
+					$wpdb->query("UPDATE $wpdb->pmpro_membership_orders SET notes = '" . esc_sql($new_notes) . "' WHERE id = '" . $order_id . "' LIMIT 1");
+
+					continue;
+				}
+
+				// If Paid Memberships Pro - Auto-Renewal Checkbox is active there may be mixed recurring and non-recurring users at this level
+				if ( $user->membership_level->cycle_number == 0 || $user->membership_level->billing_amount == 0 ) {
+					continue;
+				}
+
+				// Make sure that the user's billing structure is the same as the billing structure that we are checking for ($combo).
+				if ( $user->membership_level->cycle_number . ' ' . $user->membership_level->cycle_period != $combo ) {
+					continue;
+				}
+
+				//note when we send the reminder
+				$new_notes = $order->notes . "Reminder Sent:" . $today . "\n";
+				$wpdb->query("UPDATE $wpdb->pmpro_membership_orders SET notes = '" . esc_sql($new_notes) . "' WHERE id = '" . $order_id . "' LIMIT 1");
+
+				//setup email to send
+				$email = new PMProEmail();
+				$email->template = "check_pending_reminder";
+				$email->email = $user->user_email;
+				$email->subject = sprintf(__("Reminder: New Invoice for %s at %s", "pmpro-pay-by-check"), $user->membership_level->name, get_option("blogname"));
+				//get body from template
+				$email->body = file_get_contents(PMPRO_PAY_BY_CHECK_DIR . "/email/" . $email->template . ".html");
+
+				//setup more data
+				$email->data = array(
+					"name" => $user->display_name,
+					"user_login" => $user->user_login,
+					"sitename" => get_option("blogname"),
+					"siteemail" => get_option("pmpro_from_email"),
+					"membership_id" => $user->membership_level->id,
+					"membership_level_name" => $user->membership_level->name,
+					"membership_cost" => pmpro_getLevelCost($user->membership_level),
+					"login_link" => wp_login_url(pmpro_url("account")),
+					"display_name" => $user->display_name,
+					"user_email" => $user->user_email,
+				);
+
+				$email->data["instructions"] = wp_unslash( get_option('pmpro_instructions') );
+				$email->data["invoice_id"] = $order->code;
+				$email->data["invoice_total"] = pmpro_formatPrice($order->total);
+				$email->data["invoice_date"] = date(get_option('date_format'), $order->timestamp);
+				$email->data["billing_name"] = $order->billing->name;
+				$email->data["billing_street"] = $order->billing->street;
+				$email->data["billing_city"] = $order->billing->city;
+				$email->data["billing_state"] = $order->billing->state;
+				$email->data["billing_zip"] = $order->billing->zip;
+				$email->data["billing_country"] = $order->billing->country;
+				$email->data["billing_phone"] = $order->billing->phone;
+				$email->data["cardtype"] = $order->cardtype;
+				$email->data["accountnumber"] = hideCardNumber($order->accountnumber);
+				$email->data["expirationmonth"] = $order->expirationmonth;
+				$email->data["expirationyear"] = $order->expirationyear;
+				$email->data["billing_address"] = pmpro_formatAddress($order->billing->name,
+																	 $order->billing->street,
+																	 "", //address 2
+																	 $order->billing->city,
+																	 $order->billing->state,
+																	 $order->billing->zip,
+																	 $order->billing->country,
+																	 $order->billing->phone);
+
+				if($order->getDiscountCode())
+					$email->data["discount_code"] = "<p>" . __("Discount Code", "pmpro") . ": " . $order->discount_code->code . "</p>\n";
+				else
+					$email->data["discount_code"] = "";
+
+				//send the email
+				$email->sendEmail();
+			}
+		}
+	}
+}
+
+/*
+ * Cancel overdue check orders.
+ */
+function pmpropbc_cancel_overdue_orders_legacy()
+{
+	global $wpdb;
+
+	//make sure we only run once a day
+	$now = current_time('timestamp');
+	$today = date("Y-m-d", $now);
+
+	//have to run for each level, so get levels
+	$levels = pmpro_getAllLevels(true, true);
+
+	if(empty($levels))
+		return;
+
+	foreach($levels as $level)
+	{
+		//get options
+		$options = pmpropbc_getOptions($level->id);
+		
+		// subtract cancel_days not add, we want the older orders not paid
+		// this is relative to the date the reminder was sent out not when it was due
+		if(!empty($options['cancel_days']))
+			$date = date("Y-m-d", strtotime("- " . $options['cancel_days'] . " days", $now));
+		else
+			$date = $today;
+
+		//need to get all combos of pay cycle and period
+		$sqlQuery = "SELECT DISTINCT(CONCAT(cycle_number, ' ', cycle_period)) FROM $wpdb->pmpro_memberships_users WHERE membership_id = '" . $level->id . "' AND cycle_number > 0 AND status = 'active'";
+		$combos = $wpdb->get_col($sqlQuery);
+
+		if(empty($combos))
+			continue;
+
+		foreach($combos as $combo)
+		{
+			//get all check orders still pending after X days
+			$sqlQuery = "
+				SELECT id 
+				FROM $wpdb->pmpro_membership_orders 
+				WHERE membership_id = $level->id 
+					AND gateway = 'check' 
+					AND status = 'pending' 
+					AND timestamp <= '" . $date . "'
+					AND notes NOT LIKE '%Cancelled:%' AND notes NOT LIKE '%Cancellation Skipped:%'
+				ORDER BY id
+			";
+
+			if(defined('PMPRO_CRON_LIMIT'))
+				$sqlQuery .= " LIMIT " . PMPRO_CRON_LIMIT;
+
+			$orders = $wpdb->get_col($sqlQuery);
+
+			if(empty($orders))
+				continue;
+
+			foreach($orders as $order_id)
+			{
+				//get the order and user data
+				$order = new MemberOrder($order_id);
+
+				// If using PMPro v3.0+, only process overdue orders if the subscription is still active.
+				if ( method_exists( $order, 'get_subscription' ) ) {
+					$subscription = $order->get_subscription();
+					if ( ! empty( $subscription ) && 'active' !== $subscription->get_status() ) {
+						continue;
+					}
+				}
+
+				$user = get_userdata($order->user_id);
+				if ( $user ) {
+					$user->membership_level = pmpro_getSpecificMembershipLevelForUser( $order->user_id, $level->id );
+				}
+
+				//if they are no longer a member, let's not send them an email
+				if(empty($user->membership_level) || empty($user->membership_level->ID) || $user->membership_level->id != $order->membership_id)
+				{
+					//note when we send the reminder
+					$new_notes = $order->notes . "Cancellation Skipped:" . $today . "\n";
+					$wpdb->query("UPDATE $wpdb->pmpro_membership_orders SET notes = '" . esc_sql($new_notes) . "' WHERE id = '" . $order_id . "' LIMIT 1");
+
+					continue;
+				}
+
+				// If Paid Memberships Pro - Auto-Renewal Checkbox is active there may be mixed recurring and non-recurring users at this level
+				if ( $user->membership_level->cycle_number == 0 || $user->membership_level->billing_amount == 0 ) {
+					continue;
+				}
+
+				// Make sure that the user's billing structure is the same as the billing structure that we are checking for ($combo).
+				if ( $user->membership_level->cycle_number . ' ' . $user->membership_level->cycle_period != $combo ) {
+					continue;
+				}
+
+				//cancel the order and subscription
+				do_action("pmpro_membership_pre_membership_expiry", $order->user_id, $order->membership_id );
+
+				//remove their membership
+				pmpro_cancelMembershipLevel( $order->membership_id, $order->user_id, 'expired' );
+
+				// Update the order.
+				$order->status = 'error';
+				$order->notes .= "Cancelled:" . $today . "\n";
+				$order->saveOrder();
+
+				do_action("pmpro_membership_post_membership_expiry", $order->user_id, $order->membership_id );
+				$send_email = apply_filters("pmpro_send_expiration_email", true, $order->user_id);
+				if($send_email)
+				{
+					//send an email
+					$pmproemail = new PMProEmail();
+					$euser = get_userdata($order->user_id);
+					$pmproemail->sendMembershipExpiredEmail($euser);
+					if(current_user_can('manage_options'))
+						printf(__("Membership expired email sent to %s. ", "pmpro"), $euser->user_email);
+					else
+						echo ". ";
+				}
+			}
+		}
+	}
+}

--- a/pmpro-pay-by-check.php
+++ b/pmpro-pay-by-check.php
@@ -27,6 +27,8 @@ Domain Path: /languages
 define( 'PMPRO_PAY_BY_CHECK_DIR', dirname(__FILE__) );
 define( 'PMPROPBC_VER', '0.12' );
 
+include_once( PMPRO_PAY_BY_CHECK_DIR . '/includes/deprecated.php' );
+
 /*
 	Load plugin textdomain.
 */
@@ -763,13 +765,13 @@ add_filter( 'pmpro_confirmation_message', 'pmpropbc_confirmation_message', 10, 2
 */
 
 /**
- * Send Invoice to user if/when changing order status to "success" for Check based payment.
+ * Send Invoice to user when changing order status to "success" for Check based payment.
  *
  * @param MemberOrder $morder - Updated order as it's being saved
  */
 function pmpropbc_send_invoice_email( $morder ) {
-    // Only worry about this if this is a check order that is now in "success" status.
-    if ( 'check' !== strtolower( $morder->payment_type ) || 'success' !== $morder->status ) {
+    // Only worry about this if this is a check order.
+    if ( 'check' !== strtolower( $morder->payment_type ) ) {
 		return;
 	}
 
@@ -781,228 +783,255 @@ function pmpropbc_send_invoice_email( $morder ) {
 		}
 	}
 
-	// Check order meta to see if an invoice email has already been sent for this order.
-	if ( function_exists( 'get_pmpro_membership_order_meta' ) && get_pmpro_membership_order_meta( $morder->id, 'pmpropbc_invoice_email_sent', true ) ) {
-		return;
-	}
-
-	// Make sure that the user still has the membership level for this order.
-	if ( ! pmpro_hasMembershipLevel( $morder->membership_id, $morder->user_id ) ) {
-		return;
-	}
-
 	$recipient = get_user_by( 'ID', $morder->user_id );
-
 	$invoice_email = new PMProEmail();
 	$invoice_email->sendInvoiceEmail( $recipient, $morder );
-
-	// Update order meta to indicate that an invoice email has been sent.
-	if ( function_exists( 'update_pmpro_membership_order_meta' ) ) {
-		update_pmpro_membership_order_meta( $morder->id, 'pmpropbc_invoice_email_sent', true );
-	}
 }
+add_action( 'pmpro_order_status_success', 'pmpropbc_send_invoice_email', 10, 1 );
 
-add_action( 'pmpro_updated_order', 'pmpropbc_send_invoice_email', 10, 1 );
-/*
-	Create pending orders for recurring levels.
-*/
-function pmpropbc_recurring_orders()
-{
+/**
+ *	Process recurring orders.
+ */
+function pmpropbc_recurring_orders() {
 	global $wpdb;
 
-	//make sure we only run once a day
-	$now = current_time('timestamp');
-	$today = date("Y-m-d", $now);
-
-	//have to run for each level, so get levels
-	$levels = pmpro_getAllLevels(true, true);
-
-	if(empty($levels))
+	// If not using PMPro v3.0, run the legacy function.
+	if ( ! class_exists( 'PMPro_Subscription' ) ) {
+		pmpropbc_recurring_orders_legacy();
 		return;
+	}
 
-	foreach($levels as $level)
-	{
-		//get options
+	// Get all levels that we will check for.
+	$levels = pmpro_getAllLevels(true, true);
+	if ( empty( $levels ) ) {
+		$levels = array();
+	}
+
+	// Loop through all levels.
+	foreach ( $levels as $level ) {
+		// Get options for the level.
 		$options = pmpropbc_getOptions($level->id);
-		if(!empty($options['renewal_days']))
-			$date = date("Y-m-d", strtotime("+ " . $options['renewal_days'] . " days", $now));
-		else
-			$date = $today;
 
-		//need to get all combos of pay cycle and period
-		$sqlQuery = "SELECT DISTINCT(CONCAT(cycle_number, ' ', cycle_period)) FROM $wpdb->pmpro_memberships_users WHERE membership_id = '" . $level->id . "' AND cycle_number > 0 AND status = 'active'";
-		$combos = $wpdb->get_col($sqlQuery);
+		// Get the cutoffs for each 'stage'.
+		$renewal_days          = empty( $options['renewal_days'] ) ? 0 : $options['renewal_days'];
+		$create_order_cutoff   = date('Y-m-d H:i:s', strtotime( '+ ' . $renewal_days . ' days', current_time( 'timestamp' ) ));
+		$reminder_days         = empty( $options['reminder_days'] ) ? 0 : $options['reminder_days'];
+		$reminder_order_cutoff = date('Y-m-d H:i:s', strtotime( '- ' . $reminder_days . ' days', current_time( 'timestamp' ) ));
+		$cancel_days           = empty( $options['cancel_days'] ) ? 0 : $options['cancel_days'];
+		$cancel_order_cutoff   = date('Y-m-d H:i:s', strtotime( '- ' . $cancel_days . ' days', current_time( 'timestamp' ) ));
 
-		if(empty($combos))
-			continue;
+		// Get all the subscriptions that we need to check.
+		$subscription_query_results = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT * FROM $wpdb->pmpro_subscriptions WHERE status = 'active' AND membership_level_id = %d AND next_payment_date <= %s AND gateway = 'check' ORDER BY next_payment_date ASC",
+				$level->id,
+				$create_order_cutoff
+			)
+		);
 
-		foreach($combos as $combo)
-		{
-			//check if it's been one pay period since the last payment
-			/*
-				- Check should create an invoice X days before expiration based on a setting on the levels page.
-				- Set invoice date based on cycle and the day of the month of the member start date.
-				- Send a reminder email Y days after initial invoice is created if it's still pending.
-				- Cancel membership after Z days if invoice is not paid. Send email.
-// ADDED Extra brackets round OR as sql results were missing some orders (match for same user id was not being used due to the missing brackets) 
-			*/
-			//get all check orders still pending after X days
-			$sqlQuery = "
-				SELECT o1.id FROM
-				    (SELECT mo.id, mo.user_id, mo.timestamp
-				    FROM {$wpdb->pmpro_membership_orders} AS mo
-				    WHERE mo.membership_id = $level->id
-				        AND mo.gateway = 'check'
-				        AND mo.status IN('pending', 'success')
-				    ) as o1
+		// Loop through all subscriptions.
+		foreach ( $subscription_query_results as $subscription_query_result ) {
+			// Get the PMPro_Subscription object.
+			$subscription = new PMPro_Subscription( $subscription_query_result->id );
 
-					LEFT OUTER JOIN 
-					
-					(SELECT mo1.id, mo1.user_id, mo1.timestamp
-				    FROM {$wpdb->pmpro_membership_orders} AS mo1
-				    WHERE mo1.membership_id = $level->id
-				        AND mo1.gateway = 'check'
-				        AND mo1.status IN('pending', 'success')
-				    ) as o2
+			// Get the most recent pending order.
+			$pending_orders = $subscription->get_orders(
+				array(
+					'status' => 'pending',
+					'limit'  => 1,
+				)
+			);
+			$pending_order = ! empty( $pending_orders ) ? $pending_orders[0] : null;
 
-					ON o1.user_id = o2.user_id
-					AND (o1.timestamp < o2.timestamp
-					OR (o1.timestamp = o2.timestamp AND o1.id < o2.id))
-				WHERE
-					o2.id IS NULL
-					AND DATE_ADD(o1.timestamp, INTERVAL $combo) <= '" . $date . "'
-			";
+			// Get the most recent successful order.
+			$success_orders = $subscription->get_orders(
+				array(
+					'status' => 'success',
+					'limit'  => 1,
+				)
+			);
+			$success_order = ! empty( $success_orders ) ? $success_orders[0] : null;
 
-			if(defined('PMPRO_CRON_LIMIT'))
-				$sqlQuery .= " LIMIT " . PMPRO_CRON_LIMIT;
-
-			$orders = $wpdb->get_col($sqlQuery);
-
-			if(empty($orders))
+			// If the timestamp of either the pending or successful order is after the subscription's next payment date by more than a day, then the subscription data is off.
+			// Update the subscription and continue to the next subscription.
+			$pending_order_timestamp = ! empty( $pending_order ) ? strtotime( $pending_order->timestamp ) : 0;
+			$success_order_timestamp = ! empty( $success_order ) ? strtotime( $success_order->timestamp ) : 0;
+			$latest_order_timestamp = max( $pending_order_timestamp, $success_order_timestamp );
+			if ( $latest_order_timestamp > $subscription->get_next_payment_date() + 86400 ) {
+				$subscription->update();
 				continue;
+			}
 
-			foreach($orders as $order_id)
-			{
-				$order = new MemberOrder($order_id);
+			// Get the user.
+			$user = get_userdata( $subscription->get_user_id() );
 
-				// If using PMPro v3.0+, only create a pending order if the subscription is still active.
-				if ( method_exists( $order, 'get_subscription' ) ) {
-					$subscription = $order->get_subscription();
-					if ( ! empty( $subscription ) && 'active' !== $subscription->get_status() ) {
-						continue;
+			// Handle order creation.
+			if ( $subscription->get_next_payment_date( 'Y-m-d H:i:s' ) <= $create_order_cutoff ) {
+				// If no pending orders exist, we need to create one.
+				if ( empty( $pending_order ) ) {
+					// Create a new order.
+					$pending_order = new MemberOrder();
+					$pending_order->user_id = $subscription->get_user_id();
+					$pending_order->membership_id = $subscription->get_membership_level_id();
+					$pending_order->InitialPayment = $subscription->get_billing_amount();
+					$pending_order->PaymentAmount = $subscription->get_billing_amount();
+					$pending_order->BillingPeriod = $subscription->get_cycle_period();
+					$pending_order->BillingFrequency = $subscription->get_cycle_number();
+					$pending_order->subscription_transaction_id = $subscription->get_subscription_transaction_id();
+					$pending_order->gateway = 'check';
+					$pending_order->payment_type = 'Check';
+					$pending_order->status = 'pending';
+					$pending_order->timestamp = $subscription->get_next_payment_date();
+
+					// Copy billing address from last order.
+					if ( ! empty( $success_order ) ) {
+						$pending_order->billing = new stdClass();
+						$pending_order->billing->name = $success_order->billing->name;
+						$pending_order->billing->street = $success_order->billing->street;
+						$pending_order->billing->city = $success_order->billing->city;
+						$pending_order->billing->state = $success_order->billing->state;
+						$pending_order->billing->zip = $success_order->billing->zip;
+						$pending_order->billing->country = $success_order->billing->country;
+					}
+
+					// Save the order.
+					$pending_order->saveOrder();
+
+					// Send an invoice email.
+					if ( ! empty( $user ) ) {
+						$email = new PMProEmail();
+						$email->template = 'check_pending';
+						$email->email = $user->user_email;
+						$email->subject = sprintf( __( 'New Invoice for %s at %s', 'pmpro-pay-by-check' ), $level->name, get_option( 'blogname' ) );
+
+						// Get body from template.
+						$email->body = file_get_contents(PMPRO_PAY_BY_CHECK_DIR . '/email/' . $email->template . '.html');
+
+						// Set up more data.
+						$email->data = array(
+							'name' => $user->display_name,
+							'user_login' => $user->user_login,
+							'sitename' => get_option('blogname'),
+							'siteemail' => pmpro_getOption('from_email'),
+							'membership_id' => $user->membership_level->id,
+							'membership_level_name' => $user->membership_level->name,
+							'membership_cost' => pmpro_getLevelCost($user->membership_level),
+							'login_link' => wp_login_url(pmpro_url('account')),
+							'display_name' => $user->display_name,
+							'user_email' => $user->user_email,
+							'instructions' => wp_unslash( pmpro_getOption('instructions') ),
+							'invoice_id' => $pending_order->code,
+							'invoice_total' => pmpro_formatPrice($pending_order->total),
+							'invoice_date' => date(get_option('date_format'), $pending_order->timestamp),
+							'billing_name' => $pending_order->billing->name,
+							'billing_street' => $pending_order->billing->street,
+							'billing_city' => $pending_order->billing->city,
+							'billing_state' => $pending_order->billing->state,
+							'billing_zip' => $pending_order->billing->zip,
+							'billing_country' => $pending_order->billing->country,
+							'billing_phone' => $pending_order->billing->phone,
+							'cardtype' => $pending_order->cardtype,
+							'accountnumber' => hideCardNumber($pending_order->accountnumber),
+							'expirationmonth' => $pending_order->expirationmonth,
+							'expirationyear' => $pending_order->expirationyear,
+							'billing_address' => pmpro_formatAddress($pending_order->billing->name,
+																$pending_order->billing->street,
+																'', //address 2
+																$pending_order->billing->city,
+																$pending_order->billing->state,
+																$pending_order->billing->zip,
+																$pending_order->billing->country,
+																$pending_order->billing->phone),
+							'discount_code' => $pending_order->getDiscountCode() ? '<p>' . __('Discount Code', 'pmpro-pay-by-check') . ': ' . $pending_order->discount_code->code . '</p>\n' : '',
+
+						);
+
+						// Send the email.
+						$email->sendEmail();
 					}
 				}
+			}
 
-				$user = get_userdata($order->user_id);
-				if ( $user ) {
-					$user->membership_level = pmpro_getSpecificMembershipLevelForUser( $order->user_id, $level->id );
+			// Handle reminder emails.
+			if ( $subscription->get_next_payment_date( 'Y-m-d H:i:s' ) <= $reminder_order_cutoff ) {
+				// If we have a pending order, check if a reminder email has already been sent.
+				if ( ! empty( $pending_order ) && ( empty( $pending_order->notes ) || ( ! str_contains( $pending_order->notes, 'Reminder Sent:' ) && ! str_contains( $pending_order->notes, 'Reminder Skipped:' ) ) ) ) {
+					// Send a reminder email.
+					if ( ! empty( $user ) ) {
+						$email = new PMProEmail();
+						$email->template = 'check_pending_reminder';
+						$email->email = $user->user_email;
+						$email->subject = sprintf( __( 'Reminder: New Invoice for %s at %s', 'pmpro-pay-by-check' ), $level->name, get_option( 'blogname' ) );
+
+						// Get body from template.
+						$email->body = file_get_contents(PMPRO_PAY_BY_CHECK_DIR . '/email/' . $email->template . '.html');
+
+						// Set up more data.
+						$email->data = array(
+							'name' => $user->display_name,
+							'user_login' => $user->user_login,
+							'sitename' => get_option('blogname'),
+							'siteemail' => pmpro_getOption('from_email'),
+							'membership_id' => $user->membership_level->id,
+							'membership_level_name' => $user->membership_level->name,
+							'membership_cost' => pmpro_getLevelCost($user->membership_level),
+							'login_link' => wp_login_url(pmpro_url('account')),
+							'display_name' => $user->display_name,
+							'user_email' => $user->user_email,
+							'instructions' => wp_unslash( pmpro_getOption('instructions') ),
+							'invoice_id' => $pending_order->code,
+							'invoice_total' => pmpro_formatPrice($pending_order->total),
+							'invoice_date' => date(get_option('date_format'), $pending_order->timestamp),
+							'billing_name' => $pending_order->billing->name,
+							'billing_street' => $pending_order->billing->street,
+							'billing_city' => $pending_order->billing->city,
+							'billing_state' => $pending_order->billing->state,
+							'billing_zip' => $pending_order->billing->zip,
+							'billing_country' => $pending_order->billing->country,
+							'billing_phone' => $pending_order->billing->phone,
+							'cardtype' => $pending_order->cardtype,
+							'accountnumber' => hideCardNumber($pending_order->accountnumber),
+							'expirationmonth' => $pending_order->expirationmonth,
+							'expirationyear' => $pending_order->expirationyear,
+							'billing_address' => pmpro_formatAddress($pending_order->billing->name,
+																$pending_order->billing->street,
+																'', //address 2
+																$pending_order->billing->city,
+																$pending_order->billing->state,
+																$pending_order->billing->zip,
+																$pending_order->billing->country,
+																$pending_order->billing->phone),
+							'discount_code' => $pending_order->getDiscountCode() ? '<p>' . __('Discount Code', 'pmpro-pay-by-check') . ': ' . $pending_order->discount_code->code . '</p>\n' : '',
+						);
+
+						// Send the email.
+						$email->sendEmail();
+					}
+
+					// Update the order notes.
+					$pending_order->notes .= 'Reminder Sent: ' . date( 'Y-m-d', current_time( 'timestamp' ) ) . "\n";
+					$pending_order->saveOrder();
 				}
+			}
 
-				//check that user still has same level?
-				if(empty($user->membership_level) || $order->membership_id != $user->membership_level->id)
-					continue;
+			// Handle cancellation.
+			if ( $subscription->get_next_payment_date( 'Y-m-d H:i:s' ) <= $cancel_order_cutoff ) {
+				// Cancel the user's membership, which will also cancel the subscription.
+				do_action('pmpro_membership_pre_membership_expiry', $subscription->get_user_id(), $subscription->get_membership_level_id() );
+				if ( pmpro_cancelMembershipLevel( $subscription->get_membership_level_id(), $subscription->get_user_id(), 'expired' ) ) {
+					do_action('pmpro_membership_post_membership_expiry', $subscription->get_user_id(), $subscription->get_membership_level_id() );
 
-				// If Paid Memberships Pro - Auto-Renewal Checkbox is active there may be mixed recurring and non-recurring users at this level
-				if( $user->membership_level->cycle_number == 0 || $user->membership_level->billing_amount == 0)
-				  continue;
-
-				// Make sure that the user's billing structure is the same as the billing structure that we are checking for ($combo).
-				if ( $user->membership_level->cycle_number . ' ' . $user->membership_level->cycle_period != $combo ) {
-					continue;
+					// Notify the user.
+					$send_email = apply_filters('pmpro_send_expiration_email', true, $subscription->get_user_id());
+					if ( ! empty( $user ) && $send_email ) {
+						//send an email
+						$pmproemail = new PMProEmail();
+						$pmproemail->sendMembershipExpiredEmail( $user, $subscription->get_membership_level_id() );
+					}
+				} else {
+					// Cancellation failed. Mark the subscription as cancelled.
+					$subscription->cancel_at_gateway();
 				}
-
-				//create new pending order
-				$morder = new MemberOrder();
-				$morder->user_id = $order->user_id;
-				$morder->membership_id = $user->membership_level->id;
-				$morder->InitialPayment = $user->membership_level->billing_amount;
-				$morder->PaymentAmount = $user->membership_level->billing_amount;
-				$morder->BillingPeriod = $user->membership_level->cycle_period;
-				$morder->BillingFrequency = $user->membership_level->cycle_number;
-				$morder->subscription_transaction_id = $order->subscription_transaction_id;
-				$morder->gateway = "check";
-				$morder->setGateway();
-				$morder->payment_type = "Check";
-				$morder->status = "pending";
-
-				// Copy billing addres from last order
-				$morder->billing = new stdClass();
-				$morder->billing->name = $order->billing->name;
-				$morder->billing->street = $order->billing->street;
-				$morder->billing->city = $order->billing->city;
-				$morder->billing->state = $order->billing->state;
-				$morder->billing->zip = $order->billing->zip;
-				$morder->billing->country = $order->billing->country;
-
-				//get timestamp for new order
-				$order_timestamp = strtotime("+" . $combo, $order->timestamp);
-
-				//let's skip if there is already an order for this user/level/timestamp
-				// make sure there's no order for the current order_timesamp (ignore hours/seconds and focus on the day value itself).
-				$dupe = $wpdb->get_var( "SELECT id FROM $wpdb->pmpro_membership_orders WHERE user_id = '" . esc_sql( $order->user_id ) . "' AND membership_id = '" . esc_sql( $order->membership_id ) . "' AND timestamp LIKE '" . esc_sql( date( 'Y-m-d', $order_timestamp ) ) . "%' LIMIT 1" );
-
-				if(!empty($dupe))
-					continue;
-
-				//save it
-				$morder->process();
-				$morder->timestamp = $order_timestamp;
-				$morder->saveOrder();
-
-				//send emails
-				$email = new PMProEmail();
-				$email->template = "check_pending";
-				$email->email = $user->user_email;
-				$email->subject = sprintf(__("New Invoice for %s at %s", "pmpro-pay-by-check"), $user->membership_level->name, get_option("blogname"));
-
-				//get body from template
-				$email->body = file_get_contents(PMPRO_PAY_BY_CHECK_DIR . "/email/" . $email->template . ".html");
-
-				//setup more data
-				$email->data = array(
-					"name" => $user->display_name,
-					"user_login" => $user->user_login,
-					"sitename" => get_option("blogname"),
-					"siteemail" => pmpro_getOption("from_email"),
-					"membership_id" => $user->membership_level->id,
-					"membership_level_name" => $user->membership_level->name,
-					"membership_cost" => pmpro_getLevelCost($user->membership_level),
-					"login_link" => wp_login_url(pmpro_url("account")),
-					"display_name" => $user->display_name,
-					"user_email" => $user->user_email,
-				);
-
-				$email->data["instructions"] = wp_unslash(  pmpro_getOption('instructions') );
-				$email->data["invoice_id"] = $morder->code;
-				$email->data["invoice_total"] = pmpro_formatPrice($morder->total);
-				$email->data["invoice_date"] = date(get_option('date_format'), $morder->timestamp);
-				$email->data["billing_name"] = $morder->billing->name;
-				$email->data["billing_street"] = $morder->billing->street;
-				$email->data["billing_city"] = $morder->billing->city;
-				$email->data["billing_state"] = $morder->billing->state;
-				$email->data["billing_zip"] = $morder->billing->zip;
-				$email->data["billing_country"] = $morder->billing->country;
-				$email->data["billing_phone"] = $morder->billing->phone;
-				$email->data["cardtype"] = $morder->cardtype;
-				$email->data["accountnumber"] = hideCardNumber($morder->accountnumber);
-				$email->data["expirationmonth"] = $morder->expirationmonth;
-				$email->data["expirationyear"] = $morder->expirationyear;
-				$email->data["billing_address"] = pmpro_formatAddress($morder->billing->name,
-																	 $morder->billing->street,
-																	 "", //address 2
-																	 $morder->billing->city,
-																	 $morder->billing->state,
-																	 $morder->billing->zip,
-																	 $morder->billing->country,
-																	 $morder->billing->phone);
-
-				if($morder->getDiscountCode())
-					$email->data["discount_code"] = "<p>" . __("Discount Code", "pmpro") . ": " . $morder->discount_code->code . "</p>\n";
-				else
-					$email->data["discount_code"] = "";
-
-				//send the email
-				$email->sendEmail();
 			}
 		}
 	}
@@ -1010,287 +1039,32 @@ function pmpropbc_recurring_orders()
 add_action('pmpropbc_recurring_orders', 'pmpropbc_recurring_orders');
 
 /*
-	Send reminder emails for pending invoices.
-*/
-function pmpropbc_reminder_emails()
-{
-	global $wpdb;
-
-	//make sure we only run once a day
-	$now = current_time('timestamp');
-	$today = date("Y-m-d", $now);
-
-	//have to run for each level, so get levels
-	$levels = pmpro_getAllLevels(true, true);
-
-	if(empty($levels))
+ * Send reminder emails for overdue check orders.
+ */
+function pmpropbc_reminder_emails() {
+	// If not using PMPro v3.0, run the legacy function.
+	if ( ! class_exists( 'PMPro_Subscription' ) ) {
+		pmpropbc_reminder_emails_legacy();
 		return;
-
-	foreach($levels as $level)
-	{
-		//get options
-		$options = pmpropbc_getOptions($level->id);
-		// subtract reminder_days from current date as we are looking for invoices from or before that date
-		// this is relative to the date the reminder was sent out not when it was due I think
-		if(!empty($options['reminder_days']))
-			$date = date("Y-m-d", strtotime("- " . $options['reminder_days'] . " days", $now));
-		else
-			$date = $today;
-
-		//need to get all combos of pay cycle and period
-		$sqlQuery = "SELECT DISTINCT(CONCAT(cycle_number, ' ', cycle_period)) FROM $wpdb->pmpro_memberships_users WHERE membership_id = '" . $level->id . "' AND cycle_number > 0 AND status = 'active'";
-		$combos = $wpdb->get_col($sqlQuery);
-
-		if(empty($combos))
-			continue;
-
-		foreach($combos as $combo)
-		{
-			//get all check orders still pending after X days
-		  // don't add the INTERVAL here!
-			$sqlQuery = "
-				SELECT id 
-				FROM $wpdb->pmpro_membership_orders 
-				WHERE membership_id = $level->id 
-					AND gateway = 'check' 
-					AND status = 'pending' 
-					AND timestamp <= '" . $date . "'
-					AND notes NOT LIKE '%Reminder Sent:%' AND notes NOT LIKE '%Reminder Skipped:%'
-				ORDER BY id
-			";
-
-			if(defined('PMPRO_CRON_LIMIT'))
-				$sqlQuery .= " LIMIT " . PMPRO_CRON_LIMIT;
-
-			$orders = $wpdb->get_col($sqlQuery);
-
-			if(empty($orders))
-				continue;
-
-			foreach($orders as $order_id)
-			{
-				//get some data
-				$order = new MemberOrder($order_id);
-
-				// If using PMPro v3.0+, only send reminders if the subscription is still active.
-				if ( method_exists( $order, 'get_subscription' ) ) {
-					$subscription = $order->get_subscription();
-					if ( ! empty( $subscription ) && 'active' !== $subscription->get_status() ) {
-						continue;
-					}
-				}
-
-				$user = get_userdata($order->user_id);
-				if ( $user ) {
-					$user->membership_level = pmpro_getSpecificMembershipLevelForUser( $order->user_id, $level->id );
-				}
-
-				//if they are no longer a member, let's not send them an email
-				if(empty($user->membership_level) || empty($user->membership_level->ID) || $user->membership_level->id != $order->membership_id)
-				{
-					//note when we send the reminder
-					$new_notes = $order->notes . "Reminder Skipped:" . $today . "\n";
-					$wpdb->query("UPDATE $wpdb->pmpro_membership_orders SET notes = '" . esc_sql($new_notes) . "' WHERE id = '" . $order_id . "' LIMIT 1");
-
-					continue;
-				}
-
-				// If Paid Memberships Pro - Auto-Renewal Checkbox is active there may be mixed recurring and non-recurring users at this level
-				if ( $user->membership_level->cycle_number == 0 || $user->membership_level->billing_amount == 0 ) {
-					continue;
-				}
-
-				// Make sure that the user's billing structure is the same as the billing structure that we are checking for ($combo).
-				if ( $user->membership_level->cycle_number . ' ' . $user->membership_level->cycle_period != $combo ) {
-					continue;
-				}
-
-				//note when we send the reminder
-				$new_notes = $order->notes . "Reminder Sent:" . $today . "\n";
-				$wpdb->query("UPDATE $wpdb->pmpro_membership_orders SET notes = '" . esc_sql($new_notes) . "' WHERE id = '" . $order_id . "' LIMIT 1");
-
-				//setup email to send
-				$email = new PMProEmail();
-				$email->template = "check_pending_reminder";
-				$email->email = $user->user_email;
-				$email->subject = sprintf(__("Reminder: New Invoice for %s at %s", "pmpro-pay-by-check"), $user->membership_level->name, get_option("blogname"));
-				//get body from template
-				$email->body = file_get_contents(PMPRO_PAY_BY_CHECK_DIR . "/email/" . $email->template . ".html");
-
-				//setup more data
-				$email->data = array(
-					"name" => $user->display_name,
-					"user_login" => $user->user_login,
-					"sitename" => get_option("blogname"),
-					"siteemail" => get_option("pmpro_from_email"),
-					"membership_id" => $user->membership_level->id,
-					"membership_level_name" => $user->membership_level->name,
-					"membership_cost" => pmpro_getLevelCost($user->membership_level),
-					"login_link" => wp_login_url(pmpro_url("account")),
-					"display_name" => $user->display_name,
-					"user_email" => $user->user_email,
-				);
-
-				$email->data["instructions"] = wp_unslash( get_option('pmpro_instructions') );
-				$email->data["invoice_id"] = $order->code;
-				$email->data["invoice_total"] = pmpro_formatPrice($order->total);
-				$email->data["invoice_date"] = date(get_option('date_format'), $order->timestamp);
-				$email->data["billing_name"] = $order->billing->name;
-				$email->data["billing_street"] = $order->billing->street;
-				$email->data["billing_city"] = $order->billing->city;
-				$email->data["billing_state"] = $order->billing->state;
-				$email->data["billing_zip"] = $order->billing->zip;
-				$email->data["billing_country"] = $order->billing->country;
-				$email->data["billing_phone"] = $order->billing->phone;
-				$email->data["cardtype"] = $order->cardtype;
-				$email->data["accountnumber"] = hideCardNumber($order->accountnumber);
-				$email->data["expirationmonth"] = $order->expirationmonth;
-				$email->data["expirationyear"] = $order->expirationyear;
-				$email->data["billing_address"] = pmpro_formatAddress($order->billing->name,
-																	 $order->billing->street,
-																	 "", //address 2
-																	 $order->billing->city,
-																	 $order->billing->state,
-																	 $order->billing->zip,
-																	 $order->billing->country,
-																	 $order->billing->phone);
-
-				if($order->getDiscountCode())
-					$email->data["discount_code"] = "<p>" . __("Discount Code", "pmpro") . ": " . $order->discount_code->code . "</p>\n";
-				else
-					$email->data["discount_code"] = "";
-
-				//send the email
-				$email->sendEmail();
-			}
-		}
 	}
+
+	// If using PMPro v3.0+, we can disable this cron as it is handled by pmpropbc_recurring_orders.
+	wp_clear_scheduled_hook('pmpropbc_reminder_emails');
 }
 add_action('pmpropbc_reminder_emails', 'pmpropbc_reminder_emails');
 
 /*
-	Cancel overdue members.
-*/
-function pmpropbc_cancel_overdue_orders()
-{
-	global $wpdb;
-
-	//make sure we only run once a day
-	$now = current_time('timestamp');
-	$today = date("Y-m-d", $now);
-
-	//have to run for each level, so get levels
-	$levels = pmpro_getAllLevels(true, true);
-
-	if(empty($levels))
+ * Cancel overdue check orders.
+ */
+function pmpropbc_cancel_overdue_orders() {
+	// If not using PMPro v3.0, run the legacy function.
+	if ( ! class_exists( 'PMPro_Subscription' ) ) {
+		pmpropbc_cancel_overdue_orders_legacy();
 		return;
-
-	foreach($levels as $level)
-	{
-		//get options
-		$options = pmpropbc_getOptions($level->id);
-		
-		// subtract cancel_days not add, we want the older orders not paid
-		// this is relative to the date the reminder was sent out not when it was due
-		if(!empty($options['cancel_days']))
-			$date = date("Y-m-d", strtotime("- " . $options['cancel_days'] . " days", $now));
-		else
-			$date = $today;
-
-		//need to get all combos of pay cycle and period
-		$sqlQuery = "SELECT DISTINCT(CONCAT(cycle_number, ' ', cycle_period)) FROM $wpdb->pmpro_memberships_users WHERE membership_id = '" . $level->id . "' AND cycle_number > 0 AND status = 'active'";
-		$combos = $wpdb->get_col($sqlQuery);
-
-		if(empty($combos))
-			continue;
-
-		foreach($combos as $combo)
-		{
-			//get all check orders still pending after X days
-			$sqlQuery = "
-				SELECT id 
-				FROM $wpdb->pmpro_membership_orders 
-				WHERE membership_id = $level->id 
-					AND gateway = 'check' 
-					AND status = 'pending' 
-					AND timestamp <= '" . $date . "'
-					AND notes NOT LIKE '%Cancelled:%' AND notes NOT LIKE '%Cancellation Skipped:%'
-				ORDER BY id
-			";
-
-			if(defined('PMPRO_CRON_LIMIT'))
-				$sqlQuery .= " LIMIT " . PMPRO_CRON_LIMIT;
-
-			$orders = $wpdb->get_col($sqlQuery);
-
-			if(empty($orders))
-				continue;
-
-			foreach($orders as $order_id)
-			{
-				//get the order and user data
-				$order = new MemberOrder($order_id);
-
-				// If using PMPro v3.0+, only process overdue orders if the subscription is still active.
-				if ( method_exists( $order, 'get_subscription' ) ) {
-					$subscription = $order->get_subscription();
-					if ( ! empty( $subscription ) && 'active' !== $subscription->get_status() ) {
-						continue;
-					}
-				}
-
-				$user = get_userdata($order->user_id);
-				if ( $user ) {
-					$user->membership_level = pmpro_getSpecificMembershipLevelForUser( $order->user_id, $level->id );
-				}
-
-				//if they are no longer a member, let's not send them an email
-				if(empty($user->membership_level) || empty($user->membership_level->ID) || $user->membership_level->id != $order->membership_id)
-				{
-					//note when we send the reminder
-					$new_notes = $order->notes . "Cancellation Skipped:" . $today . "\n";
-					$wpdb->query("UPDATE $wpdb->pmpro_membership_orders SET notes = '" . esc_sql($new_notes) . "' WHERE id = '" . $order_id . "' LIMIT 1");
-
-					continue;
-				}
-
-				// If Paid Memberships Pro - Auto-Renewal Checkbox is active there may be mixed recurring and non-recurring users at this level
-				if ( $user->membership_level->cycle_number == 0 || $user->membership_level->billing_amount == 0 ) {
-					continue;
-				}
-
-				// Make sure that the user's billing structure is the same as the billing structure that we are checking for ($combo).
-				if ( $user->membership_level->cycle_number . ' ' . $user->membership_level->cycle_period != $combo ) {
-					continue;
-				}
-
-				//cancel the order and subscription
-				do_action("pmpro_membership_pre_membership_expiry", $order->user_id, $order->membership_id );
-
-				//remove their membership
-				pmpro_cancelMembershipLevel( $order->membership_id, $order->user_id, 'expired' );
-
-				// Update the order.
-				$order->status = 'error';
-				$order->notes .= "Cancelled:" . $today . "\n";
-				$order->saveOrder();
-
-				do_action("pmpro_membership_post_membership_expiry", $order->user_id, $order->membership_id );
-				$send_email = apply_filters("pmpro_send_expiration_email", true, $order->user_id);
-				if($send_email)
-				{
-					//send an email
-					$pmproemail = new PMProEmail();
-					$euser = get_userdata($order->user_id);
-					$pmproemail->sendMembershipExpiredEmail($euser);
-					if(current_user_can('manage_options'))
-						printf(__("Membership expired email sent to %s. ", "pmpro"), $euser->user_email);
-					else
-						echo ". ";
-				}
-			}
-		}
 	}
+
+	// If using PMPro v3.0+, we can disable this cron as it is handled by pmpropbc_recurring_orders.
+	wp_clear_scheduled_hook('pmpropbc_cancel_overdue_orders');
 }
 add_action('pmpropbc_cancel_overdue_orders', 'pmpropbc_cancel_overdue_orders');
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-pay-by-check/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-pay-by-check/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
When using PMPro v3.0+, create pending orders and cancel overdue payments based on the subscriptions table.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves XXX.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
