### PR TITLE
Do not create recurring orders if last payment was from another gateway

### DIFF
--- a/pmpro-pay-by-check.php
+++ b/pmpro-pay-by-check.php
@@ -861,7 +861,6 @@ function pmpropbc_recurring_orders()
 					(SELECT mo1.id, mo1.user_id, mo1.timestamp
 				    FROM {$wpdb->pmpro_membership_orders} AS mo1
 				    WHERE mo1.membership_id = $level->id
-				        AND mo1.gateway = 'check'
 				        AND mo1.status IN('pending', 'success')
 				    ) as o2
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-pay-by-check/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-pay-by-check/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Fixed issue in PMPro v3.0+ where recurring orders could be created for old Check orders even if the last payment was from a different payment gateway.

This means that if a user paid by check and then switched to paying with Stripe, recurring check orders could still be created in `pending` status and, if not marked as `success`, the user's membership could be canceled.

The change in PMPro v3.0 that brought about this issue was the removal of the `cancelled` status. The query fix by this PR only looks for orders in `pending` or `success` status to create a recurring order for, and since orders for old memberships were in `cancelled` status previously, recurring orders would not be created for them. Now that all `cancelled` orders are now `success`, this safeguard no longer works.

The fix in this PR changes the query to say "Only create recurring order if there is an old `Check` order that does not have orders from ANY gateway following it".

The fact that all orders are now `success` means that this query is now a lot less performant. We want to update this Add On to utilize Subs Table ASAP to both fix edge cases and improve performance.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
