### PR TITLE
Only sending the cancellation email if a level was removed

### DIFF
--- a/includes/crons.php
+++ b/includes/crons.php
@@ -188,7 +188,7 @@ function pmpropbc_cancel_overdue_orders() {
 			$order = new MemberOrder($order_id);
 
 			//remove their membership
-			pmpro_cancelMembershipLevel( $order->membership_id, $order->user_id, 'cancelled' );
+			$level_removed = pmpro_cancelMembershipLevel( $order->membership_id, $order->user_id, 'cancelled' );
 
 			// Update the order.
 			$order->status = 'error';
@@ -197,7 +197,7 @@ function pmpropbc_cancel_overdue_orders() {
 
 			// Send an email to the member.
 			$user = get_userdata( $order->user_id );
-			if ( ! empty( $user ) ) {
+			if ( ! empty( $user ) && $level_removed ) {
 				$email = new PMProEmail();
 				$email->sendCancelEmail( $user, $order->membership_id );
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-pay-by-check/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-pay-by-check/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Avoids sending a membership cancellation email in cases where a user submitted a checkout but their first payment was never received.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
