### PR TITLE
Small update to show check instructions in a box for v3.1+

### DIFF
--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -264,10 +264,6 @@ function pmpropbc_pmpro_checkout_after_payment_information_fields() {
 	if( !empty($options) && $options['setting'] > 0 ) {
 		$instructions = get_option("pmpro_instructions");
 		$check_gateway_label = get_option( 'pmpro_check_gateway_label' );
-		if($gateway != 'check')
-			$hidden = 'style="display:none;"';
-		else
-			$hidden = '';
 		?>
 		<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_card pmpro_check_instructions', 'pmpro_check_instructions' ) ); ?>" <?php echo $gateway != 'check' ? 'style="display:none;"' : ''; ?>>
 			<h2 class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_card_title pmpro_font-large' ) ); ?>"><?php echo esc_html( sprintf( __( 'Pay by %s', 'pmpro-pay-by-check' ), $check_gateway_label ) ); ?></h2>

--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -263,12 +263,18 @@ function pmpropbc_pmpro_checkout_after_payment_information_fields() {
 
 	if( !empty($options) && $options['setting'] > 0 ) {
 		$instructions = get_option("pmpro_instructions");
+		$check_gateway_label = get_option( 'pmpro_check_gateway_label' );
 		if($gateway != 'check')
 			$hidden = 'style="display:none;"';
 		else
 			$hidden = '';
 		?>
-		<div class="pmpro_check_instructions" <?php echo $hidden; ?>><?php echo wp_kses_post( $instructions ); ?></div>
+		<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_card pmpro_check_instructions', 'pmpro_check_instructions' ) ); ?>" <?php echo $gateway != 'check' ? 'style="display:none;"' : ''; ?>>
+			<h2 class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_card_title pmpro_font-large' ) ); ?>"><?php echo esc_html( sprintf( __( 'Pay by %s', 'pmpro-pay-by-check' ), $check_gateway_label ) ); ?></h2>
+			<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_card_content' ) ); ?>">
+				<?php echo wp_kses_post( $instructions ); ?>
+			</div> <!-- end pmpro_card_content -->
+		</div> <!-- end pmpro_check_instructions -->
 		<?php
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-pay-by-check/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-pay-by-check/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
The check instructions were missed in our first pass here. This updates the instructions to also use the design as in core's check gateway.

### Screenshots

How it looks with previous versions of PMPro
![Screenshot 2024-07-12 at 5 32 10 AM](https://github.com/user-attachments/assets/eabd664c-e299-434d-b36e-9f2d5b458289)

How it looks with v3.1+ of PMPro
![Screenshot 2024-07-12 at 5 32 37 AM](https://github.com/user-attachments/assets/74430c22-327b-4f63-9060-a321535d78e8)
