### PR TITLE
Fix subscriptions being immediately cancelled

### DIFF
--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -342,15 +342,20 @@ function pmpropbc_order_status_success( $morder ) {
 		return;
 	}
 
+	// Check if we are switching to success status.
+	if ( 'success' !== $morder->status || 'success' === $morder->original_status) {
+		return;
+	}
+
 	// Check if the order was a chekout order.
 	$checkout_request_vars = get_pmpro_membership_order_meta( $morder->id, 'checkout_request_vars', true );
 	if ( ! empty( $checkout_request_vars ) ) {
 		// Process the checkout and avoid infinite loops. This should send the checkout email.
 		$original_request_vars = $_REQUEST;
 		pmpro_pull_checkout_data_from_order( $morder );
-		remove_action( 'pmpro_order_status_success', 'pmpropbc_order_status_success', 10, 1 );
+		remove_action( 'pmpro_update_order', 'pmpropbc_order_status_success', 10, 1 );
 		pmpro_complete_async_checkout( $morder );
-		add_action( 'pmpro_order_status_success', 'pmpropbc_order_status_success', 10, 1 );
+		add_action( 'pmpro_update_order', 'pmpropbc_order_status_success', 10, 1 );
 		$_REQUEST = $original_request_vars;
 	} else {
 		// Send an invoice email for the order.
@@ -362,4 +367,4 @@ function pmpropbc_order_status_success( $morder ) {
 		pmpropbc_update_subscription_data_for_order( $morder );
 	}
 }
-add_action( 'pmpro_order_status_success', 'pmpropbc_order_status_success', 10, 1 );
+add_action( 'pmpro_update_order', 'pmpropbc_order_status_success', 10, 1 );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
If the user has a membership level and purchases it again with a subscription, the new subscription will be immediately canceled. This is happening because:
1. The order was being saved in `success` status before the level changed occurred
2. This caused the PMPro_Subscription entry to be added before level change
3. During level change, all existing subscriptions for cancelled levels are deleted

The fix: Initiate the level change before the order is saved in "success" status

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
