### PR TITLE
Delay calling pmpro_getLevelAtCheckout() until the checkout level is retrieved

### DIFF
--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -152,14 +152,16 @@ add_action("wp_enqueue_scripts", 'pmpropbc_enqueue_scripts');
 	Need to remove some filters added by the check gateway.
 	The default gateway will have it's own idea RE this.
 */
-function pmpropbc_init_include_billing_address_fields()
-{
+function pmpropbc_init_include_billing_address_fields( $level = null) {
 	//make sure PMPro is active
 	if(!function_exists('pmpro_getGateway'))
 		return;
 
 	//billing address and payment info fields
-	$level = pmpro_getLevelAtCheckout();
+	if ( empty( $level ) ) {
+		$level = pmpro_getLevelAtCheckout();
+	}
+
 	if ( ! empty( $level->id ) )
 	{
 		$options = pmpropbc_getOptions( $level->id );
@@ -227,7 +229,7 @@ function pmpropbc_init_include_billing_address_fields()
 	remove_filter('pmpro_checkout_after_payment_information_fields', array('PMProGateway_check', 'pmpro_checkout_after_payment_information_fields'));
 	add_filter('pmpro_checkout_after_payment_information_fields', 'pmpropbc_pmpro_checkout_after_payment_information_fields');		
 }
-add_action('init', 'pmpropbc_init_include_billing_address_fields', 20);
+add_action( 'pmpro_checkout_preheader_after_get_level_at_checkout', 'pmpropbc_init_include_billing_address_fields', 20, 1 );
 
 /**
  * Cancels all previously pending check orders if a user purchases the same level via a different payment method.


### PR DESCRIPTION
If we call `pmpro_getLevelAtCheckout()`, the incorrect value may be cached for that function. This will cause issues with PayPal Express in PMPro v3.2.

### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-pay-by-check/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-pay-by-check/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves XXX.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
