### PR TITLE
Setting the order total directly on recurring payments

### DIFF
--- a/includes/crons.php
+++ b/includes/crons.php
@@ -76,6 +76,8 @@ function pmpropbc_recurring_orders() {
 			$pending_order = new MemberOrder();
 			$pending_order->user_id = $subscription->get_user_id();
 			$pending_order->membership_id = $subscription->get_membership_level_id();
+			$pending_order->total = $subscription->get_billing_amount();
+			$pending_order->subtotal = $subscription->get_billing_amount();
 			$pending_order->InitialPayment = $subscription->get_billing_amount();
 			$pending_order->PaymentAmount = $subscription->get_billing_amount();
 			$pending_order->BillingPeriod = $subscription->get_cycle_period();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-pay-by-check/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-pay-by-check/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Likely since the MemberOrder cleanup work in PMPro v2.2, recurring orders created by PBC are being created with a $0 total. This fixes that issue by directly setting the total and subtotal when creating recurring orders instead of relying on the `InitialPayment` and `PaymentAmount` dynamic properties.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
