### PR TITLE
Make sure that the order gateway is check if the level is check only

### DIFF
--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -281,6 +281,27 @@ function pmpropbc_pmpro_checkout_after_payment_information_fields() {
 }
 
 /**
+ * Make sure that orders have the "check" gateway if
+ * the level is set to "check only".
+ *
+ * @since TBD
+ *
+ * @param MemberOrder $order The checkout order object.
+ * @return MemberOrder
+ */
+function pmpropbc_checkout_order( $order ) {
+	// Check if this level is check only.
+	$options = pmpropbc_getOptions( $order->membership_id );
+	if ( $options['setting'] == 2 ) {
+		// This is a check only level. Make sure that the order is set to the check gateway.
+		$order->setGateway( 'check' );
+	}
+
+	return $order;
+}
+add_filter( 'pmpro_checkout_order', 'pmpropbc_checkout_order' );
+
+/**
  * When getting the gateway object for a "check" order/subscription, swap it
  * for our custom "check" gateway.
  *


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-pay-by-check/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-pay-by-check/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Resolves #132 

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:
Steps to reproduce the behavior:

Have Stripe (Checkout), the PayPal Express Add On and the Pay by Check Add On active
My level had an initial amount, expiration date, and the 'Allow Paying by Check' setting set to 'Users can only pay by check'
Checkout with this level
You'll automatically be redirected to Stripe Checkout

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
