### PR TITLE
Including tax amount on recurring orders

### DIFF
--- a/includes/crons.php
+++ b/includes/crons.php
@@ -100,8 +100,6 @@ function pmpropbc_recurring_orders() {
 			$pending_order = new MemberOrder();
 			$pending_order->user_id = $subscription->get_user_id();
 			$pending_order->membership_id = $subscription->get_membership_level_id();
-			$pending_order->total = $subscription->get_billing_amount();
-			$pending_order->subtotal = $subscription->get_billing_amount();
 			$pending_order->InitialPayment = $subscription->get_billing_amount();
 			$pending_order->PaymentAmount = $subscription->get_billing_amount();
 			$pending_order->BillingPeriod = $subscription->get_cycle_period();
@@ -112,6 +110,9 @@ function pmpropbc_recurring_orders() {
 			$pending_order->status = 'pending';
 			$pending_order->timestamp = $subscription->get_next_payment_date();
 			$pending_order->find_billing_address();
+			$pending_order->subtotal = $subscription->get_billing_amount();
+			$pending_order->tax = pmpro_round_price( $pending_order->getTaxForPrice( $pending_order->subtotal ) );
+			$pending_order->total = $pending_order->subtotal + $pending_order->tax;
 
 			// Save the order.
 			$pending_order->saveOrder();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-pay-by-check/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-pay-by-check/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves #136 

### How to test the changes in this Pull Request:

1. Use the `pmpro_tax` filter to apply a tax on checkout e.g. https://gist.github.com/dwanjuki/c9ceaa536d5662e58d1a6a0da6736332
2. Complete checkout for a recurring membership.
3. Check recurring orders for the subscription.
4. Observe that tax is included on both the initial order and recurring orders, if the conditions for the tax are met.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fixed an issue where tax would not be included on recurring check orders.