### PR TITLE
Prevent membership cancellation for unpaid early renewals

### DIFF
--- a/includes/crons.php
+++ b/includes/crons.php
@@ -213,8 +213,15 @@ function pmpropbc_cancel_overdue_orders() {
 			// Get the order object.
 			$order = new MemberOrder($order_id);
 
-			//remove their membership
-			$level_removed = pmpro_cancelMembershipLevel( $order->membership_id, $order->user_id, 'cancelled' );
+			// Get the membership level object from the order
+			$membership_level = $order->getMembershipLevel();
+
+			// Remove the membership if it's recurring
+			if ( pmpro_isLevelRecurring( $membership_level ) ) {
+				$level_removed = pmpro_cancelMembershipLevel( $order->membership_id, $order->user_id, 'cancelled' );
+			} else {
+				$level_removed = false;
+			}
 
 			// Update the order.
 			$order->status = 'error';


### PR DESCRIPTION
Cancel membership only if the _overdue_ pending order is for a recurring subscription. For manual renewals, update the _overdue_ order leaving membership as is.

### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-pay-by-check/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-pay-by-check/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves #32

### How to test the changes in this Pull Request:

1. Check out for a non-recurring membership eg. annual
2. Change the order status to _success_ to complete checkout and assign membership.
3. Complete another checkout for the same membership level. Leave order _pending_.
4. Wait for the order to be overdue, or adjust order date backwards. 
5. Trigger or wait for _pmpropbc_cancel_overdue_orders_ cron 
6. Observe that the membership level is retained and that the overdue order status changes to _error_.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fixed an issue where non-recurring memberships could be cancelled before their expiration date.
