### PR TITLE
No longer showing level confirmation message if membership is not confirmed (order is pending)

### DIFF
--- a/includes/frontend.php
+++ b/includes/frontend.php
@@ -80,12 +80,6 @@ function pmpropbc_confirmation_message( $confirmation_message, $invoice ) {
 	
 	$confirmation_message = '<p>' . sprintf( __( 'Thank you for your membership to %1$s. Your %2$s membership status is: <b>%3$s</b>.', 'pmpro-pay-by-check' ), get_bloginfo( 'name' ), $invoice->membership_level->name, $invoice->status ) . ' ' . __( 'Once payment is received and processed you will gain access to your membership content.', 'pmpro-pay-by-check' ) . '</p>';
 
-	// Put the level confirmation from level settings into the message.
-	$level_obj = pmpro_getLevel( $invoice->membership_id );
-	if ( ! empty( $level_obj->confirmation ) ) {
-		$confirmation_message .= wpautop( wp_unslash( $level_obj->confirmation ) );
-	}
-
 	$confirmation_message .= '<p>' . sprintf( __( 'Below are details about your membership account and a receipt for your initial membership invoice. A welcome email with a copy of your initial membership invoice has been sent to %s.', 'pmpro-pay-by-check' ), $user->user_email ) . '</p>';
 
 	// Put the check instructions into the message.


### PR DESCRIPTION
### All Submissions:
* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-pay-by-check/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-pay-by-check/pulls/) for the same update/change?
<!-- Mark completed items with an [x] -->
<!-- You can erase any parts of this template not applicable to your Pull Request. -->
### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR updates the Pay by Check Add On so that the membership level's confirmation message is no longer displayed on the confirmation page until the order's payment has been confirmed (i.e., the order status is `success`).

Previously, the level confirmation message was shown on the confirmation page regardless of the order status. This was problematic because:
- The confirmation message may contain "members-only" content that is either protected and inaccessible to the pending user, or misleadingly appears accessible when it shouldn't be.
- For consistency, PMPro core is being updated in 3.8 to gate the confirmation message behind an active (success) order status.
- The pending checkout email for Pay by Check already does not include the confirmation message, so this aligns confirmation page behavior with existing email behavior.

Since the Pay by Check Add On uses the `instructions` setting to convey next steps to manual pay users, the level confirmation message is not needed during the pending state. If sites want to "add back" the level confirmation message for pending PBC orders without the success status gate, this can be done via the existing confirmation page filter (a gist can be provided as a reference).

### How to test the changes in this Pull Request:
1. Set up a membership level with a confirmation message containing distinct content (e.g., "Welcome, members-only link here").
2. Enable the Pay by Check Add On and configure instructions text.
3. Check out for that level using Pay by Check so the resulting order is in `pending` status.
4. View the confirmation page and verify the level's confirmation message is NOT displayed (only the PBC instructions should show).
5. Update the order status to `success` in the admin.
6. Reload the confirmation page and verify the level's confirmation message IS now displayed.
### Other information:
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?
<!-- Mark completed items with an [x] -->
### Changelog entry

* BUG FIX: The membership level's confirmation message is no longer shown on the checkout confirmation page for pending Pay by Check orders. The message will now only display once the order status is updated to `success`, preventing potential exposure of members-only content to users whose payment has not yet been confirmed.